### PR TITLE
add the blindPset method to IdentityInterface

### DIFF
--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -5,7 +5,7 @@ import {
 import { Network, networks, Transaction } from 'liquidjs-lib';
 import { AddressInterface } from '../types';
 import { decodePset } from '../transaction';
-import { toHex } from '../utils';
+import { isConfidentialOutput, psetToUnsignedHex } from '../utils';
 
 /**
  * Enumeration of all the Identity types.
@@ -107,7 +107,7 @@ export default class Identity {
     const outputsKeys: Map<number, Buffer> = new Map<number, Buffer>();
 
     const pset = decodePset(psetBase64);
-    const transaction = Transaction.fromHex(toHex(psetBase64));
+    const transaction = Transaction.fromHex(psetToUnsignedHex(psetBase64));
 
     // set the outputs map
     for (const index of outputsToBlind) {
@@ -129,10 +129,7 @@ export default class Identity {
 
       // continue if the input witness is unconfidential
       if (input.witnessUtxo) {
-        if (
-          !input.witnessUtxo.rangeProof ||
-          !input.witnessUtxo.surjectionProof
-        ) {
+        if (!isConfidentialOutput(input.witnessUtxo)) {
           continue;
         }
 
@@ -142,7 +139,7 @@ export default class Identity {
       if (input.nonWitnessUtxo) {
         const vout = transaction.ins[index].index;
         const witness = Transaction.fromBuffer(input.nonWitnessUtxo).outs[vout];
-        if (!witness.rangeProof || !witness.surjectionProof) {
+        if (!isConfidentialOutput(witness)) {
           continue;
         }
 

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -2,8 +2,10 @@ import {
   EsploraIdentityRestorer,
   IdentityRestorerInterface,
 } from './identityRestorer';
-import { Network, networks } from 'liquidjs-lib';
+import { Network, networks, Transaction } from 'liquidjs-lib';
 import { AddressInterface } from '../types';
+import { decodePset } from '../transaction';
+import { toHex } from '../utils';
 
 /**
  * Enumeration of all the Identity types.
@@ -35,6 +37,12 @@ export interface IdentityInterface {
   getAddresses(): AddressInterface[];
   getBlindingPrivateKey(script: string): string;
   isAbleToSign(): boolean;
+  blindPset(
+    psetBase64: string,
+    outputsIndexToBlind: number[],
+    outputsPubKeysByIndex?: Map<number, string>,
+    inputsPrivKeysByIndex?: Map<number, string>
+  ): Promise<string>;
 }
 
 /**
@@ -79,5 +87,77 @@ export default class Identity {
     } else {
       this.restorer = Identity.DEFAULT_RESTORER;
     }
+  }
+
+  async blindPsetWithBlindKeysGetter(
+    getBlindingKeyPair: (
+      script: Buffer
+    ) => { publicKey: Buffer; privateKey: Buffer },
+    psetBase64: string,
+    outputsToBlind: number[],
+    outputsPubKeys?: Map<number, string>,
+    inputsPrivKeys?: Map<number, string>
+  ): Promise<string> {
+    const inputsKeys: Map<number, Buffer> = new Map<number, Buffer>();
+    const outputsKeys: Map<number, Buffer> = new Map<number, Buffer>();
+
+    const pset = decodePset(psetBase64);
+    const transaction = Transaction.fromHex(toHex(psetBase64));
+
+    // set the outputs map
+    for (const index of outputsToBlind) {
+      if (outputsPubKeys && outputsPubKeys.has(index)) {
+        const pubKey = Buffer.from(outputsPubKeys.get(index)!, 'hex');
+        outputsKeys.set(index, pubKey);
+        continue;
+      }
+
+      const { script } = transaction.outs[index];
+      const pubKey = getBlindingKeyPair(script).publicKey;
+      outputsKeys.set(index, pubKey);
+    }
+
+    // set the inputs map
+    for (let index = 0; index < pset.data.inputs.length; index++) {
+      const input = pset.data.inputs[index];
+      let script: Buffer | undefined = undefined;
+
+      // continue if the input witness is unconfidential
+      if (input.witnessUtxo) {
+        if (
+          !input.witnessUtxo.rangeProof ||
+          !input.witnessUtxo.surjectionProof
+        ) {
+          continue;
+        }
+
+        script = input.witnessUtxo.script;
+      }
+
+      if (input.nonWitnessUtxo) {
+        const vout = transaction.ins[index].index;
+        const witness = Transaction.fromBuffer(input.nonWitnessUtxo).outs[vout];
+        if (!witness.rangeProof || !witness.surjectionProof) {
+          continue;
+        }
+
+        script = witness.script;
+      }
+
+      if (inputsPrivKeys && inputsPrivKeys.has(index)) {
+        const privKey = Buffer.from(inputsPrivKeys.get(index)!, 'hex');
+        inputsKeys.set(index, privKey);
+        continue;
+      }
+
+      if (!script) {
+        throw new Error('no witness script for input #' + index);
+      }
+
+      const privKey = getBlindingKeyPair(script).privateKey;
+      inputsKeys.set(index, privKey);
+    }
+
+    return pset.blindOutputsByIndex(inputsKeys, outputsKeys).toBase64();
   }
 }

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -38,9 +38,14 @@ export interface IdentityInterface {
   getBlindingPrivateKey(script: string): string;
   isAbleToSign(): boolean;
   blindPset(
+    // the pset to blind
     psetBase64: string,
+    // the output to blind, specifided by output index
     outputsIndexToBlind: number[],
+    // optional: an outputs index to hex encoded blinding pub key
+    // only useful for non-wallet outputs
     outputsPubKeysByIndex?: Map<number, string>,
+    // optional, same as ouputsPubKeysIndex
     inputsPrivKeysByIndex?: Map<number, string>
   ): Promise<string>;
 }

--- a/src/identity/masterpubkey.ts
+++ b/src/identity/masterpubkey.ts
@@ -9,10 +9,12 @@ import {
   isValidXpub,
   isValidExtendedBlindKey,
   toXpub,
+  toHex,
 } from '../utils';
 import { BIP32Interface, fromBase58 } from 'bip32';
 import { Slip77Interface, fromMasterBlindingKey } from 'slip77';
-import { payments } from 'liquidjs-lib';
+import { payments, Transaction } from 'liquidjs-lib';
+import { decodePset } from '../transaction';
 
 export interface MasterPublicKeyOptsValue {
   masterPublicKey: string;
@@ -93,6 +95,21 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
         throw new Error(`Error during restoration step: ${reason}`);
       });
     }
+  }
+
+  async blindPset(
+    psetBase64: string,
+    outputsToBlind: number[],
+    outputsPubKeys?: Map<number, string>,
+    inputsPrivKeys?: Map<number, string>
+  ): Promise<string> {
+    return super.blindPsetWithBlindKeysGetter(
+      (script: Buffer) => this.getBlindingKeyPair(script),
+      psetBase64,
+      outputsToBlind,
+      outputsPubKeys,
+      inputsPrivKeys
+    );
   }
 
   isAbleToSign(): boolean {

--- a/src/identity/masterpubkey.ts
+++ b/src/identity/masterpubkey.ts
@@ -9,12 +9,10 @@ import {
   isValidXpub,
   isValidExtendedBlindKey,
   toXpub,
-  toHex,
 } from '../utils';
 import { BIP32Interface, fromBase58 } from 'bip32';
 import { Slip77Interface, fromMasterBlindingKey } from 'slip77';
-import { payments, Transaction } from 'liquidjs-lib';
-import { decodePset } from '../transaction';
+import { payments } from 'liquidjs-lib';
 
 export interface MasterPublicKeyOptsValue {
   masterPublicKey: string;

--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -120,6 +120,21 @@ export class Mnemonic extends Identity implements IdentityInterface {
     }
   }
 
+  async blindPset(
+    psetBase64: string,
+    outputsToBlind: number[],
+    outputsPubKeys?: Map<number, string>,
+    inputsPrivKeys?: Map<number, string>
+  ): Promise<string> {
+    return super.blindPsetWithBlindKeysGetter(
+      (script: Buffer) => this.getBlindingKeyPair(script),
+      psetBase64,
+      outputsToBlind,
+      outputsPubKeys,
+      inputsPrivKeys
+    );
+  }
+
   isAbleToSign(): boolean {
     return true;
   }

--- a/src/identity/privatekey.ts
+++ b/src/identity/privatekey.ts
@@ -81,6 +81,34 @@ export class PrivateKey extends Identity implements IdentityInterface {
     this.scriptPubKey = p2wpkh.output!;
   }
 
+  async blindPset(
+    psetBase64: string,
+    outputsToBlind: number[],
+    outputsPubKeys?: Map<number, string>,
+    inputsPrivKeys?: Map<number, string>
+  ): Promise<string> {
+    return super.blindPsetWithBlindKeysGetter(
+      (script: Buffer) => this.getBlindingKeyPair(script),
+      psetBase64,
+      outputsToBlind,
+      outputsPubKeys,
+      inputsPrivKeys
+    );
+  }
+
+  private getBlindingKeyPair(
+    script: Buffer
+  ): { publicKey: Buffer; privateKey: Buffer } {
+    if (!script.equals(this.scriptPubKey)) {
+      throw new Error(script + ' is unknown by the PrivateKey Identity');
+    }
+
+    return {
+      publicKey: this.blindingKeyPair.publicKey,
+      privateKey: this.blindingKeyPair.privateKey!,
+    };
+  }
+
   isAbleToSign(): boolean {
     return true;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,11 +78,15 @@ function bufferNotEmptyOrNull(buffer?: Buffer): boolean {
  * Checks if a given output is a confidential one.
  * @param output the ouput to check.
  */
-export function isConfidentialOutput(output: TxOutput): boolean {
+export function isConfidentialOutput({
+  rangeProof,
+  surjectionProof,
+  nonce,
+}: any): boolean {
   return (
-    bufferNotEmptyOrNull(output.rangeProof) &&
-    bufferNotEmptyOrNull(output.surjectionProof) &&
-    output.nonce !== emptyNonce
+    bufferNotEmptyOrNull(rangeProof) &&
+    bufferNotEmptyOrNull(surjectionProof) &&
+    nonce !== emptyNonce
   );
 }
 
@@ -187,7 +191,7 @@ export function isValidExtendedBlindKey(masterBlind: string): Boolean {
   return true;
 }
 
-export function toHex(psetBase64: string): string {
+export function psetToUnsignedHex(psetBase64: string): string {
   let pset: Psbt;
   try {
     pset = Psbt.fromBase64(psetBase64);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { confidential, Network, TxOutput } from 'liquidjs-lib';
+import { confidential, Network, Psbt, TxOutput } from 'liquidjs-lib';
 import { UnblindOutputResult } from 'liquidjs-lib/types/confidential';
 // @ts-ignore
 import b58 from 'bs58check';
@@ -185,4 +185,15 @@ export function isValidExtendedBlindKey(masterBlind: string): Boolean {
   }
 
   return true;
+}
+
+export function toHex(psetBase64: string): string {
+  let pset: Psbt;
+  try {
+    pset = Psbt.fromBase64(psetBase64);
+  } catch (ignore) {
+    throw new Error('Invalid pset');
+  }
+
+  return pset.data.globalMap.unsignedTx.toBuffer().toString('hex');
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -51,20 +51,6 @@ export class Wallet implements WalletInterface {
     const pset = new Psbt({ network: this.network });
     return pset.toBase64();
   }
-
-  static toHex(psetBase64: string): string {
-    let pset: Psbt;
-    try {
-      pset = Psbt.fromBase64(psetBase64);
-    } catch (ignore) {
-      throw new Error('Invalid pset');
-    }
-
-    pset.validateSignaturesOfAllInputs();
-    pset.finalizeAllInputs();
-
-    return pset.extractTransaction().toHex();
-  }
 }
 
 /**

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -100,14 +100,6 @@ describe('buildTx', () => {
       addFee: true,
     });
 
-    // const pset = decodePset(unsignedTx);
-
-    // const privKeyBuffer = Buffer.from(senderBlindingKey, 'hex');
-    // pset.blindOutputsByIndex(
-    //   new Map().set(0, privKeyBuffer).set(1, privKeyBuffer),
-    //   new Map().set(2, address.fromConfidential(senderAddress).blindingKey)
-    // );
-
     const blindedBase64 = await sender.blindPset(unsignedTx, [2]);
     const signedBase64 = await sender.signPset(blindedBase64);
     const signedPset = decodePset(signedBase64);

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -1,4 +1,4 @@
-import { networks, address, Psbt } from 'liquidjs-lib';
+import { networks, Psbt } from 'liquidjs-lib';
 import {
   recipientAddress,
   senderAddress,
@@ -100,15 +100,16 @@ describe('buildTx', () => {
       addFee: true,
     });
 
-    const pset = decodePset(unsignedTx);
+    // const pset = decodePset(unsignedTx);
 
-    const privKeyBuffer = Buffer.from(senderBlindingKey, 'hex');
-    pset.blindOutputsByIndex(
-      new Map().set(0, privKeyBuffer).set(1, privKeyBuffer),
-      new Map().set(2, address.fromConfidential(senderAddress).blindingKey)
-    );
+    // const privKeyBuffer = Buffer.from(senderBlindingKey, 'hex');
+    // pset.blindOutputsByIndex(
+    //   new Map().set(0, privKeyBuffer).set(1, privKeyBuffer),
+    //   new Map().set(2, address.fromConfidential(senderAddress).blindingKey)
+    // );
 
-    const signedBase64 = await sender.signPset(pset.toBase64());
+    const blindedBase64 = await sender.blindPset(unsignedTx, [2]);
+    const signedBase64 = await sender.signPset(blindedBase64);
     const signedPset = decodePset(signedBase64);
 
     const hex = signedPset


### PR DESCRIPTION
**This PR adds `blindPset` to `IdentityInterface` and his implementations in `MasterPubKey`, `Mnemonic` and `PrivateKey`**

- `blindPset` accepts 4 arguments: (1) the pset base64 encoded to blind, (2) an array specifying the ouputs indexes to blind, (3) outputs public keys map (output index --> hex encoded pub key) and (4) inputs private blinding keys map (input index --> hex encoded private key).
- arguments (3) & (4) are optional. The `blindPset` fetches _wallet blinding keys_ using the Identity instance **if** **the blinding key is not specified in (3) & (4)**. The idea is to provide only the non-wallet blinding keys.
- the implementations for `MasterPubKey`, `Mnemonic` and `PrivateKey` are exactly the same, except the `getBlindingKeys` strategy: that's why a more abstract method is used in `Identity` class: the `blindPsetWithBlindKeysGetter` method (this avoid a lot of code duplication)
- tests: add a test in Mnemonic test file + use PrivateKey.blindPset in transaction.test.ts

it closes #9 

@tiero @altafan please review
