### PR TITLE
Fix buildTx bug 

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,12 @@
 import { UtxoInterface, Outpoint } from './types';
-import { confidential, Network, TxOutput, networks, Psbt } from 'liquidjs-lib';
+import {
+  confidential,
+  Network,
+  TxOutput,
+  networks,
+  Psbt,
+  Transaction,
+} from 'liquidjs-lib';
 import { UnblindOutputResult } from 'liquidjs-lib/types/confidential';
 // @ts-ignore
 import b58 from 'bs58check';
@@ -201,6 +208,10 @@ export function psetToUnsignedHex(psetBase64: string): string {
   }
 
   return pset.data.globalMap.unsignedTx.toBuffer().toString('hex');
+}
+
+export function psetToUnsignedTx(ptx: string): Transaction {
+  return Transaction.fromHex(psetToUnsignedHex(ptx));
 }
 
 export function toOutpoint({ txid, vout }: UtxoInterface): Outpoint {

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -6,7 +6,7 @@ import {
   sender,
   senderBlindingKey,
 } from './fixtures/wallet.keys';
-import { APIURL, broadcastTx, faucet, mint, sleep } from './_regtest';
+import { APIURL, broadcastTx, faucet, mint } from './_regtest';
 import { buildTx, BuildTxArgs, decodePset } from '../src/transaction';
 import * as assert from 'assert';
 import { RecipientInterface } from '../src/types';
@@ -25,9 +25,6 @@ describe('buildTx', () => {
     // mint and fund with USDT
     const minted = await mint(senderAddress, 100);
     USDT = minted.asset;
-
-    await sleep(3000);
-
     const senderUtxos = await fetchAndUnblindUtxos(
       [
         {
@@ -58,7 +55,6 @@ describe('buildTx', () => {
         address: recipientAddress,
       },
     ];
-
     const unsignedTx = buildTx({
       ...args,
       recipients,

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -12,6 +12,7 @@ import * as assert from 'assert';
 import { RecipientInterface } from '../src/types';
 import { greedyCoinSelector } from '../src/coinselection/greedy';
 import { fetchAndUnblindUtxos } from '../src/explorer/esplora';
+import { psetToUnsignedHex } from '../src/utils';
 
 jest.setTimeout(50000);
 
@@ -58,7 +59,13 @@ describe('buildTx', () => {
       },
     ];
 
-    const unsignedTx = buildTx({ ...args, recipients, psetBase64: tx });
+    const unsignedTx = buildTx({
+      ...args,
+      recipients,
+      psetBase64: tx,
+      addFee: true,
+    });
+    console.log(psetToUnsignedHex(unsignedTx));
     assert.doesNotThrow(() => Psbt.fromBase64(unsignedTx));
   });
 

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -12,7 +12,6 @@ import * as assert from 'assert';
 import { RecipientInterface } from '../src/types';
 import { greedyCoinSelector } from '../src/coinselection/greedy';
 import { fetchAndUnblindUtxos } from '../src/explorer/esplora';
-import { psetToUnsignedHex } from '../src/utils';
 
 jest.setTimeout(50000);
 
@@ -61,7 +60,6 @@ describe('buildTx', () => {
       psetBase64: tx,
       addFee: true,
     });
-    console.log(psetToUnsignedHex(unsignedTx));
     assert.doesNotThrow(() => Psbt.fromBase64(unsignedTx));
   });
 
@@ -82,6 +80,8 @@ describe('buildTx', () => {
   });
 
   it('should be able to create a complex transaction and broadcast it', async () => {
+    const tx = (await senderWallet).createTx();
+
     const recipients = [
       {
         asset: networks.regtest.assetHash,
@@ -95,13 +95,13 @@ describe('buildTx', () => {
       },
     ];
 
-    const tx = (await senderWallet).createTx();
     const unsignedTx = buildTx({
       ...args,
       recipients,
       psetBase64: tx,
       addFee: true,
     });
+    assert.doesNotThrow(() => Psbt.fromBase64(unsignedTx));
 
     const blindedBase64 = await sender.blindPset(unsignedTx, [2]);
     const signedBase64 = await sender.signPset(blindedBase64);


### PR DESCRIPTION
This introduces changes to fix #22. By doing so I tried to simplify the code which I found a bit overcomplicated.
This also fixes the regtest test utils in order to remove all those time sleep.

Closes #22.
Closes #18.

Please @tiero @louisinger review this.

NOTE: I didn't add the broadcasting of all the tx created in transaction.test.ts because it somehow affects the result of other unit tests. We'll possibly fix this in another PR.