### PR TITLE
add skip function argument in FetchAndUnblindTxs

### DIFF
--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -51,12 +51,14 @@ export async function fetchUtxos(address: string, url: string): Promise<any[]> {
 export async function fetchAndUnblindTxs(
   addresses: string[],
   blindingKeyGetter: BlindingKeyGetter,
-  explorerUrl: string
+  explorerUrl: string,
+  skip?: (tx: TxInterface) => boolean
 ): Promise<TxInterface[]> {
   const generator = fetchAndUnblindTxsGenerator(
     addresses,
     blindingKeyGetter,
-    explorerUrl
+    explorerUrl,
+    skip
   );
   const txs: Array<TxInterface> = [];
 
@@ -126,21 +128,24 @@ export async function fetchAndUnblindUtxos(
 }
 
 /**
- * fetch all tx associated to an address and unblind the tx's outputs and prevouts.
- * @param explorerUrl the esplora endpoint
+ * Return an async generator fetching and unblinding addresses' transactions
+ * @param addresses
+ * @param blindingKeyGetter
+ * @param explorerUrl
+ * @param skip optional, can be used to skip certain transaction
  */
 export async function* fetchAndUnblindTxsGenerator(
   addresses: string[],
   blindingKeyGetter: BlindingKeyGetter,
-  explorerUrl: string
+  explorerUrl: string,
+  skip?: (tx: TxInterface) => boolean
 ): AsyncGenerator<TxInterface, void, undefined> {
   for (const address of addresses) {
-    const txsGenerator = fetchTxsGenerator(address, explorerUrl);
+    const txsGenerator = fetchTxsGenerator(address, explorerUrl, skip);
     let txIterator = await txsGenerator.next();
     while (!txIterator.done) {
       const tx = txIterator.value;
       yield unblindTransactionPrevoutsAndOutputs(tx, blindingKeyGetter);
-
       txIterator = await txsGenerator.next();
     }
   }
@@ -153,7 +158,8 @@ export async function* fetchAndUnblindTxsGenerator(
  */
 async function* fetchTxsGenerator(
   address: string,
-  explorerUrl: string
+  explorerUrl: string,
+  skip?: (tx: TxInterface) => boolean
 ): AsyncGenerator<TxInterface, number, undefined> {
   let lastSeenTxid = undefined;
   let newTxs: EsploraTx[] = [];
@@ -175,7 +181,11 @@ async function* fetchTxsGenerator(
     );
 
     for (const tx of txs) {
-      yield await tx;
+      const transaction = await tx;
+      if (skip && skip(transaction)) {
+        continue;
+      }
+      yield transaction;
     }
   } while (newTxs.length < 25);
 

--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -180,6 +180,8 @@ async function* fetchTxsGenerator(
       lastSeenTxid
     );
 
+    if (newTxs.length === 0) break;
+    lastSeenTxid = newTxs[newTxs.length - 1].txid;
     numberOfTxs += newTxs.length;
 
     // convert them into txInterface
@@ -194,7 +196,7 @@ async function* fetchTxsGenerator(
       }
       yield transaction;
     }
-  } while (newTxs.length < 25);
+  } while (lastSeenTxid);
 
   return numberOfTxs;
 }

--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -140,15 +140,22 @@ export async function* fetchAndUnblindTxsGenerator(
   explorerUrl: string,
   skip?: (tx: TxInterface) => boolean
 ): AsyncGenerator<TxInterface, void, undefined> {
+  const txids: string[] = [];
   for (const address of addresses) {
     const txsGenerator = fetchTxsGenerator(address, explorerUrl, skip);
     let txIterator = await txsGenerator.next();
     while (!txIterator.done) {
       const tx = txIterator.value;
+      if (txids.includes(tx.txid)) {
+        continue;
+      }
+
+      txids.push(tx.txid);
       yield unblindTransactionPrevoutsAndOutputs(tx, blindingKeyGetter);
       txIterator = await txsGenerator.next();
     }
   }
+  return;
 }
 
 /**

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -14,73 +14,69 @@ import * as assert from 'assert';
 
 jest.setTimeout(80000);
 
-describe('fetchAndUnblindUtxos', () => {
+describe('esplora', () => {
   let txid: string;
 
   beforeAll(async () => {
     txid = await faucet(senderAddress);
   });
 
-  it('should unblind utxos if the blinding key is provided', async () => {
-    const senderUtxos = await fetchAndUnblindUtxos(
-      [
-        {
-          confidentialAddress: senderAddress,
-          blindingPrivateKey: senderBlindingKey,
-        },
-      ],
-      APIURL
-    );
+  describe('fetchAndUnblindUtxos', () => {
+    it('should unblind utxos if the blinding key is provided', async () => {
+      const senderUtxos = await fetchAndUnblindUtxos(
+        [
+          {
+            confidentialAddress: senderAddress,
+            blindingPrivateKey: senderBlindingKey,
+          },
+        ],
+        APIURL
+      );
 
-    const faucetUtxo = senderUtxos.find(utxo => utxo.txid === txid);
-    assert.deepStrictEqual(isBlindedUtxo(faucetUtxo!), false);
+      const faucetUtxo = senderUtxos.find(utxo => utxo.txid === txid);
+      assert.deepStrictEqual(isBlindedUtxo(faucetUtxo!), false);
+    });
+
+    it('should skip unblinding step if the skip predicate returns true', async () => {
+      const senderUtxos = await fetchAndUnblindUtxos(
+        [
+          {
+            confidentialAddress: senderAddress,
+            blindingPrivateKey: senderBlindingKey,
+          },
+        ],
+        APIURL,
+        // with this skip predicate, `txid` utxos won't be unblinded
+        (utxo: UtxoInterface) => utxo.txid === txid
+      );
+
+      const faucetUtxo = senderUtxos.find(utxo => utxo.txid === txid);
+      assert.deepStrictEqual(isBlindedUtxo(faucetUtxo!), true);
+    });
   });
 
-  it('should skip unblinding step if the skip predicate returns true', async () => {
-    const senderUtxos = await fetchAndUnblindUtxos(
-      [
-        {
-          confidentialAddress: senderAddress,
-          blindingPrivateKey: senderBlindingKey,
-        },
-      ],
-      APIURL,
-      // with this skip predicate, `txid` utxos won't be unblinded
-      (utxo: UtxoInterface) => utxo.txid === txid
-    );
+  describe('fetchAndUnblindTxs', () => {
+    it('should return txs if the blinding key is provided', async () => {
+      const senderTxs = await fetchAndUnblindTxs(
+        [senderAddress],
+        senderBlindKeyGetter,
+        APIURL
+      );
 
-    const faucetUtxo = senderUtxos.find(utxo => utxo.txid === txid);
-    assert.deepStrictEqual(isBlindedUtxo(faucetUtxo!), true);
-  });
-});
+      const faucetTx = senderTxs.find(t => t.txid === txid);
+      assert.notStrictEqual(faucetTx, undefined);
+    });
 
-describe('fetchAndUnblindTxs', () => {
-  let txid: string;
+    it('should skip transaction specified by skip function (and does not return it)', async () => {
+      const senderTxs = await fetchAndUnblindTxs(
+        [senderAddress],
+        senderBlindKeyGetter,
+        APIURL,
+        tx => tx.txid === txid
+      );
 
-  beforeAll(async () => {
-    txid = await faucet(senderAddress);
-  });
-
-  it('should return txs if the blinding key is provided', async () => {
-    const senderTxs = await fetchAndUnblindTxs(
-      [senderAddress],
-      senderBlindKeyGetter,
-      APIURL
-    );
-
-    const faucetTx = senderTxs.find(t => t.txid === txid);
-    assert.notStrictEqual(faucetTx, undefined);
-  });
-
-  it('should skip transaction specified by skip function (and does not return it)', async () => {
-    const senderTxs = await fetchAndUnblindTxs(
-      [senderAddress],
-      senderBlindKeyGetter,
-      APIURL,
-      tx => tx.txid === txid
-    );
-
-    const faucetTx = senderTxs.find(t => t.txid === txid);
-    assert.strictEqual(faucetTx, undefined);
+      const faucetTx = senderTxs.find(t => t.txid === txid);
+      assert.strictEqual(faucetTx, undefined);
+    });
   });
 });

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -1,6 +1,13 @@
 import { UtxoInterface } from './../dist/types.d';
-import { fetchAndUnblindUtxos } from '../src/explorer/esplora';
-import { senderAddress, senderBlindingKey } from './fixtures/wallet.keys';
+import {
+  fetchAndUnblindTxs,
+  fetchAndUnblindUtxos,
+} from '../src/explorer/esplora';
+import {
+  senderAddress,
+  senderBlindingKey,
+  senderBlindKeyGetter,
+} from './fixtures/wallet.keys';
 import { APIURL, faucet } from './_regtest';
 import { isBlindedUtxo } from '../src/utils';
 import * as assert from 'assert';
@@ -44,5 +51,36 @@ describe('fetchAndUnblindUtxos', () => {
 
     const faucetUtxo = senderUtxos.find(utxo => utxo.txid === txid);
     assert.deepStrictEqual(isBlindedUtxo(faucetUtxo!), true);
+  });
+});
+
+describe('fetchAndUnblindTxs', () => {
+  let txid: string;
+
+  beforeAll(async () => {
+    txid = await faucet(senderAddress);
+  });
+
+  it('should return txs if the blinding key is provided', async () => {
+    const senderTxs = await fetchAndUnblindTxs(
+      [senderAddress],
+      senderBlindKeyGetter,
+      APIURL
+    );
+
+    const faucetTx = senderTxs.find(t => t.txid === txid);
+    assert.notStrictEqual(faucetTx, undefined);
+  });
+
+  it('should skip transaction specified by skip function (and does not return it)', async () => {
+    const senderTxs = await fetchAndUnblindTxs(
+      [senderAddress],
+      senderBlindKeyGetter,
+      APIURL,
+      tx => tx.txid === txid
+    );
+
+    const faucetTx = senderTxs.find(t => t.txid === txid);
+    assert.strictEqual(faucetTx, undefined);
   });
 });

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -12,7 +12,7 @@ import { APIURL, faucet } from './_regtest';
 import { isBlindedUtxo } from '../src/utils';
 import * as assert from 'assert';
 
-jest.setTimeout(50000);
+jest.setTimeout(80000);
 
 describe('fetchAndUnblindUtxos', () => {
   let txid: string;


### PR DESCRIPTION
Similar to #31 except that the skip argument in FetchAndUnblinsTxs SKIP the **fetch and the unblinding step**. It means that the skipped transactions won't be returned by the generator.

@tiero please review