### PR TITLE
hotfix + edge test case fetchAndUnblindTxs

### DIFF
--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -147,6 +147,7 @@ export async function* fetchAndUnblindTxsGenerator(
     while (!txIterator.done) {
       const tx = txIterator.value;
       if (txids.includes(tx.txid)) {
+        txIterator = await txsGenerator.next();
         continue;
       }
 

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -78,5 +78,16 @@ describe('esplora', () => {
       const faucetTx = senderTxs.find(t => t.txid === txid);
       assert.strictEqual(faucetTx, undefined);
     });
+
+    it('should work with duplicate addresses', async () => {
+      const senderTxs = await fetchAndUnblindTxs(
+        [senderAddress, senderAddress],
+        senderBlindKeyGetter,
+        APIURL
+      );
+
+      const faucetTx = senderTxs.find(t => t.txid === txid);
+      assert.notStrictEqual(faucetTx, undefined);
+    });
   });
 });


### PR DESCRIPTION
iterate even if the txid has been fetched in `FetchAndUnblindTxsGenerator` + add edge test case in `esplora.test.ts`.

@tiero please review
