### PR TITLE
Mnemonic extends MasterPubKey

### DIFF
--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -1,13 +1,10 @@
+import { MasterPublicKey } from './masterpubkey';
 import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
 import * as bip39 from 'bip39';
 import { BIP32Interface, fromSeed as bip32fromSeed } from 'bip32';
-import { BufferMap, fromXpub } from '../utils';
-import { ECPair, Psbt, bip32, payments } from 'liquidjs-lib';
-import Identity, {
-  IdentityInterface,
-  IdentityOpts,
-  IdentityType,
-} from './identity';
+import { fromXpub } from '../utils';
+import { ECPair, Psbt, bip32, networks, Network } from 'liquidjs-lib';
+import { IdentityInterface, IdentityOpts, IdentityType } from './identity';
 import { Slip77Interface, fromSeed as slip77fromSeed } from 'slip77';
 import { AddressInterface } from '../types';
 
@@ -20,22 +17,6 @@ function instanceOfMnemonicOptsValue(value: any): value is MnemonicOptsValue {
   return 'mnemonic' in value;
 }
 
-interface AddressInterfaceExtended {
-  address: AddressInterface;
-  signingPrivateKey: string;
-  derivationPath: string;
-}
-
-// util function that parse a derivation path and return the index
-function getIndex(addrExtended: AddressInterfaceExtended) {
-  const derivationPathSplitted = addrExtended.derivationPath.split('/');
-  const index: number = parseInt(
-    derivationPathSplitted[derivationPathSplitted.length - 1]
-  );
-
-  return index;
-}
-
 /**
  * @class Mnemonic
  * Get a mnemonic as parameter to set up an HD Wallet.
@@ -45,28 +26,14 @@ function getIndex(addrExtended: AddressInterfaceExtended) {
  * @member index the next index used to derive the base node (for signing key pairs).
  * @member scriptToAddressCache a map scriptPubKey --> address generation.
  */
-export class Mnemonic extends Identity implements IdentityInterface {
-  static INITIAL_BASE_PATH: string = "m/84'/0'/0'";
-  static INITIAL_INDEX: number = 0;
-
-  private baseDerivationPath: string = Mnemonic.INITIAL_BASE_PATH;
-  private index: number = Mnemonic.INITIAL_INDEX;
-  private changeIndex: number = Mnemonic.INITIAL_INDEX;
-  private scriptToAddressCache: BufferMap<
-    AddressInterfaceExtended
-  > = new BufferMap();
-
+export class Mnemonic extends MasterPublicKey implements IdentityInterface {
   readonly masterPrivateKeyNode: BIP32Interface;
   readonly masterBlindingKeyNode: Slip77Interface;
 
   public masterPublicKey: string;
   public masterBlindingKey: string;
 
-  readonly isRestored: Promise<boolean>;
-
   constructor(args: IdentityOpts) {
-    super(args);
-
     // check the identity type
     if (args.type !== IdentityType.Mnemonic) {
       throw new Error('The identity arguments have not the Mnemonic type.');
@@ -93,32 +60,38 @@ export class Mnemonic extends Identity implements IdentityInterface {
     // retreive the wallet's seed from mnemonic
     const walletSeed = bip39.mnemonicToSeedSync(args.value.mnemonic);
     // generate the master private key from the wallet seed
-    this.masterPrivateKeyNode = bip32fromSeed(walletSeed, this.network);
+    const network = (networks as Record<string, Network>)[args.chain];
+    const masterPrivateKeyNode = bip32fromSeed(walletSeed, network);
 
     // compute and expose the masterPublicKey in this.masterPublicKey
-    const baseNode = this.masterPrivateKeyNode.derivePath(
-      this.baseDerivationPath
+    const baseNode = masterPrivateKeyNode.derivePath(
+      MasterPublicKey.INITIAL_BASE_PATH
     );
+
     const pubkey = baseNode.publicKey;
     const accountPublicKey = bip32
       .fromPublicKey(pubkey, baseNode.chainCode, baseNode.network)
       .toBase58();
 
-    this.masterPublicKey = fromXpub(accountPublicKey, args.chain);
+    const masterPublicKey = fromXpub(accountPublicKey, args.chain);
 
     // generate the master blinding key from the seed
-    this.masterBlindingKeyNode = slip77fromSeed(walletSeed);
-    this.masterBlindingKey = this.masterBlindingKeyNode.masterKey.toString(
-      'hex'
-    );
+    const masterBlindingKeyNode = slip77fromSeed(walletSeed);
+    const masterBlindingKey = masterBlindingKeyNode.masterKey.toString('hex');
 
-    this.isRestored = new Promise(() => true);
-    if (args.initializeFromRestorer) {
-      // restore from restorer
-      this.isRestored = this.restore().catch((reason: any) => {
-        throw new Error(`Error during restoration step: ${reason}`);
-      });
-    }
+    super({
+      ...args,
+      type: IdentityType.MasterPublicKey,
+      value: {
+        masterPublicKey,
+        masterBlindingKey,
+      },
+    });
+
+    this.masterBlindingKey = masterBlindingKey;
+    this.masterBlindingKeyNode = masterBlindingKeyNode;
+    this.masterPublicKey = masterPublicKey;
+    this.masterPrivateKeyNode = masterPrivateKeyNode;
   }
 
   async blindPset(
@@ -128,7 +101,7 @@ export class Mnemonic extends Identity implements IdentityInterface {
     inputsBlindingDataLike?: Map<number, BlindingDataLike>
   ): Promise<string> {
     return super.blindPsetWithBlindKeysGetter(
-      (script: Buffer) => this.getBlindingKeyPair(script),
+      (script: Buffer) => super.getBlindingKeyPair(script),
       psetBase64,
       outputsToBlind,
       outputsPubKeys,
@@ -140,117 +113,18 @@ export class Mnemonic extends Identity implements IdentityInterface {
     return true;
   }
 
-  private getCurrentDerivationPath(isChange: boolean): string {
-    const changeValue: number = isChange ? 1 : 0;
-    return `${this.baseDerivationPath}/${changeValue}`;
-  }
-
   /**
    * return the next keypair derivated from the baseNode.
    * increment the private member index +1.
    */
-  private deriveKeyWithIndex(
-    isChange: boolean,
-    index: number
+  private derivePath(
+    derivationPath: string
   ): { publicKey: Buffer; privateKey: Buffer } {
-    const baseNode = this.masterPrivateKeyNode.derivePath(
-      this.getCurrentDerivationPath(isChange)
-    );
-    const wif: string = baseNode.derive(index).toWIF();
+    const wif: string = this.masterPrivateKeyNode
+      .derivePath(derivationPath)
+      .toWIF();
     const { publicKey, privateKey } = ECPair.fromWIF(wif, this.network);
     return { publicKey: publicKey!, privateKey: privateKey! };
-  }
-
-  /**
-   * Derives the script given as parameter to a keypair (SLIP77).
-   * @param scriptPubKey script to derive.
-   */
-  private getBlindingKeyPair(
-    scriptPubKey: Buffer
-  ): { publicKey: Buffer; privateKey: Buffer } {
-    const { publicKey, privateKey } = this.masterBlindingKeyNode.derive(
-      scriptPubKey
-    );
-    return { publicKey: publicKey!, privateKey: privateKey! };
-  }
-
-  private scriptFromPublicKey(publicKey: Buffer): Buffer {
-    return payments.p2wpkh({
-      pubkey: publicKey,
-      network: this.network,
-    }).output!;
-  }
-
-  private createConfidentialAddress(
-    signingPublicKey: Buffer,
-    blindingPublicKey: Buffer
-  ): string {
-    return payments.p2wpkh({
-      pubkey: signingPublicKey,
-      blindkey: blindingPublicKey,
-      network: this.network,
-    }).confidentialAddress!;
-  }
-
-  // store the generation inside local cache
-  private persistAddressToCache(address: AddressInterfaceExtended): void {
-    const privateKeyBuffer = Buffer.from(address.signingPrivateKey, 'hex');
-    const publicKey: Buffer = ECPair.fromPrivateKey(privateKeyBuffer, {
-      network: this.network,
-    }).publicKey!;
-    const script = this.scriptFromPublicKey(publicKey);
-    this.scriptToAddressCache.set(script, address);
-  }
-
-  private getAddress(
-    isChange: boolean,
-    index: number
-  ): AddressInterfaceExtended {
-    // get the next key pair
-    const signingKeyPair = this.deriveKeyWithIndex(isChange, index);
-    // use the public key to compute the scriptPubKey
-    const script: Buffer = this.scriptFromPublicKey(signingKeyPair.publicKey);
-    // generate the blindKeyPair from the scriptPubKey
-    const blindingKeyPair = this.getBlindingKeyPair(script);
-    // with blindingPublicKey & signingPublicKey, generate the confidential address
-    const confidentialAddress = this.createConfidentialAddress(
-      signingKeyPair.publicKey,
-      blindingKeyPair.publicKey
-    );
-    // create the address generation object
-    const path = `${this.baseDerivationPath}/${isChange ? 1 : 0}/${index}`;
-    const newAddressGeneration: AddressInterfaceExtended = {
-      address: {
-        confidentialAddress: confidentialAddress!,
-        blindingPrivateKey: blindingKeyPair.privateKey!.toString('hex'),
-        derivationPath: path,
-      },
-      derivationPath: path,
-      signingPrivateKey: signingKeyPair.privateKey!.toString('hex'),
-    };
-    // return the generation data
-    return newAddressGeneration;
-  }
-
-  getNextAddress(): AddressInterface {
-    const addr = this.getAddress(false, this.index);
-    this.persistAddressToCache(addr);
-    this.index += 1;
-    return addr.address;
-  }
-
-  getNextChangeAddress(): AddressInterface {
-    const addr = this.getAddress(true, this.changeIndex);
-    this.persistAddressToCache(addr);
-    this.changeIndex += 1;
-    return addr.address;
-  }
-
-  getBlindingPrivateKey(script: string): string {
-    const scriptPubKeyBuffer = Buffer.from(script, 'hex');
-    return this.getBlindingKeyPair(scriptPubKeyBuffer).privateKey.toString(
-      'hex'
-    );
   }
 
   async signPset(psetBase64: string): Promise<string> {
@@ -266,10 +140,9 @@ export class Mnemonic extends Identity implements IdentityInterface {
 
         if (addressGeneration) {
           // if there is an address generated for the input script: build the signing key pair.
-          const privateKeyBuffer = Buffer.from(
-            addressGeneration.signingPrivateKey,
-            'hex'
-          );
+          const privateKeyBuffer = this.derivePath(
+            addressGeneration.address.derivationPath!
+          ).privateKey;
           const signingKeyPair = ECPair.fromPrivateKey(privateKeyBuffer);
           // add the promise to array
           signInputPromises.push(pset.signInputAsync(index, signingKeyPair));
@@ -284,121 +157,6 @@ export class Mnemonic extends Identity implements IdentityInterface {
 
   // returns all the addresses generated
   getAddresses(): AddressInterface[] {
-    return this.scriptToAddressCache
-      .values()
-      .map(addrExtended => addrExtended.address);
-  }
-
-  // RESTORATION PART
-
-  /**
-   * generate a range of addresses asynchronously.
-   * @param fromIndex generation will begin at index `fromIndex`
-   * @param numberToGenerate number of addresses to generate.
-   * @param change is change?
-   */
-  private async generateSetOfAddresses(
-    fromIndex: number,
-    numberToGenerate: number,
-    change: boolean
-  ): Promise<AddressInterfaceExtended[]> {
-    // asynchronous getAddress function
-    const getAddressAsync = async (
-      index: number
-    ): Promise<AddressInterfaceExtended> => {
-      return this.getAddress(change, index);
-    };
-
-    // index of addresses to generate.
-    const indexToGenerate = Array.from(
-      { length: numberToGenerate },
-      (_, i) => i + fromIndex
-    );
-
-    // return a promise when all addresses are generated.
-    return Promise.all(indexToGenerate.map(getAddressAsync));
-  }
-
-  private async checkAddressesWithRestorer(
-    addresses: AddressInterfaceExtended[]
-  ): Promise<boolean[]> {
-    const confidentialAddresses: string[] = addresses.map(
-      addrI => addrI.address.confidentialAddress
-    );
-
-    const results: boolean[] = await this.restorer.addressesHaveBeenUsed(
-      confidentialAddresses
-    );
-
-    return results;
-  }
-
-  private async restoreAddresses(): Promise<AddressInterfaceExtended[]> {
-    const NOT_USED_ADDRESSES_LIMIT = 20;
-    let restoredAddresses: AddressInterfaceExtended[] = [];
-
-    for (let i = 0; i < 2; i++) {
-      const change = i === 1;
-      let counter = 0;
-      let index = 0;
-
-      const usedAddresses: AddressInterfaceExtended[] = [];
-      const incrementOrResetCounter = (
-        addresses: AddressInterfaceExtended[]
-      ) => (hasBeenUsed: boolean, index: number) => {
-        counter++;
-        if (hasBeenUsed) {
-          counter = 0;
-          usedAddresses.push(addresses[index]);
-        }
-      };
-
-      while (counter < NOT_USED_ADDRESSES_LIMIT) {
-        // generate addresses to test
-        const addressesToTest = await this.generateSetOfAddresses(
-          index,
-          NOT_USED_ADDRESSES_LIMIT - counter,
-          change
-        );
-        // test all addresses asynchronously using restorer.
-        const hasBeenUsedArray: boolean[] = await this.checkAddressesWithRestorer(
-          addressesToTest
-        );
-
-        // iterate through array
-        // if address has been used before = push to restoredAddresses array
-        // else increment counter
-        hasBeenUsedArray.forEach(incrementOrResetCounter(addressesToTest));
-        index += NOT_USED_ADDRESSES_LIMIT;
-      }
-
-      // Set the index
-      const allIndex = usedAddresses.map(getIndex);
-      if (!change) {
-        this.index =
-          allIndex.length > 0
-            ? Math.max(...allIndex) + 1
-            : Mnemonic.INITIAL_INDEX;
-      } else {
-        this.changeIndex =
-          allIndex.length > 0
-            ? Math.max(...allIndex) + 1
-            : Mnemonic.INITIAL_INDEX;
-      }
-      restoredAddresses = restoredAddresses.concat(usedAddresses);
-    }
-
-    // return the restored address
-    return restoredAddresses;
-  }
-
-  /**
-   * Restore try to (1) generate and verify a range of addresses & (2) persist the address to the instance cache.
-   * Then it returns true if everything is ok.
-   */
-  private async restore(): Promise<boolean> {
-    const restoredAddresses = await this.restoreAddresses();
-    restoredAddresses.forEach(addr => this.persistAddressToCache(addr));
-    return true;
+    return super.getAddresses();
   }
 }

--- a/test/masterpubkey.identity.test.ts
+++ b/test/masterpubkey.identity.test.ts
@@ -93,7 +93,6 @@ describe('Identity: Master Pub Key', () => {
             'el1qqtdlqfxu94x0hkktqwwkeucn3wxvfwtq2lm35kwh7k2vnrtszzcelhhk3vvrccwqc2kkpvvctat37ffvcncsj04dwjx4m2ze6',
           derivationPath: "m/84'/0'/0'/1/5",
         },
-        derivationPath: "m/84'/0'/0'/1/5",
         publicKey:
           '0212df6a58be8fc11396b413678a863c7b8a76abdcf2e1cae2fe4fe5818b93dd37',
       });

--- a/test/mnemonic.identity.test.ts
+++ b/test/mnemonic.identity.test.ts
@@ -73,7 +73,7 @@ const unvalidMnemonicOpts: IdentityOpts = {
   },
 };
 
-describe('Identity: Private key', () => {
+describe('Identity: Mnemonic', () => {
   describe('Constructor', () => {
     const validMnemonic = new Mnemonic(validOpts);
 
@@ -239,9 +239,8 @@ describe('Identity: Private key', () => {
             'el1qqtvm33xtfrnusggyarpjsj20hphwwlduvlwvvufk387rhu74u95snxpe2shf9zg2ck6ah3l2wterg0c0chxtyka5dpy37wshr',
           derivationPath: "m/84'/0'/0'/0/42",
         },
-        derivationPath: "m/84'/0'/0'/0/42",
-        signingPrivateKey:
-          '336af0763eb44969ad7e0ddd91bfc46d374fa26ffa231a4bfd1e587ddb5b3a8a',
+        publicKey:
+          '03cc94a5ccfeafe3c6f9a15cc821ac197d1112f0c066673117b239524da6c66320',
       });
     });
 


### PR DESCRIPTION
**This PR removes derivationPath member in `AddressInterfaceExtended` and implements MasterPubKey as super-class of Mnemonic.**

- Mnemonic signature becomes  `Mnemonic extends MasterPublicKey implements IdentityInterface` -> it avoids copy/paste each time we need to modify something in MasterPubKey/Mnemonic.
- backward compatible (does not break the current tests).

it closes #41 

@tiero @Janaka-Steph please review