### PR TITLE
fetchTx and makeUnblindUrl functions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,8 @@ export interface UnblindedOutputInterface {
   script: string;
   value: number;
   asset: string;
+  valueBlinder: string;
+  assetBlinder: string;
 }
 
 export interface InputInterface {

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -4,7 +4,6 @@ import {
   fetchAndUnblindTxs,
   fetchAndUnblindUtxos,
   fetchPrevoutAndTryToUnblindUtxo,
-  getUnblindURLFromTx,
   isBlindedUtxo,
 } from '../src';
 import {

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -4,6 +4,7 @@ import {
   fetchAndUnblindTxs,
   fetchAndUnblindUtxos,
   fetchPrevoutAndTryToUnblindUtxo,
+  getUnblindURLFromTx,
   isBlindedUtxo,
 } from '../src';
 import {


### PR DESCRIPTION
This PR adds blinders to TxInterface outputs, export a new function `FetchTx` and a `makeUnblindURL` function.

- `makeUnblindUrl` can be used to create explorer's URL with query string containing blinding data. `getUnblindUrlFromTx` makes the same thing using a `TxInterface` as an argument.
- `FetchTx` uses esplora to get a `TxInterface` using a Tx ID.

@tiero please review