### PR TITLE
[HOTFIX] log unblind errors in fetchAndAndUnblindTxsGenerator instead of throw

### DIFF
--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -1,51 +1,31 @@
 import {
-  AddressInterface,
   BlindedOutputInterface,
-  BlindingKeyGetter,
-  InputInterface,
   TxInterface,
   UnblindedOutputInterface,
-  UtxoInterface,
   isBlindedOutputInterface,
+  InputInterface,
 } from '../types';
-import { Transaction, TxOutput, confidential } from 'liquidjs-lib';
+import { Transaction, TxOutput } from 'liquidjs-lib';
 import { isConfidentialOutput, toAssetHash, toNumber } from '../utils';
 import { EsploraTx, EsploraUtxo } from './types';
 import axios from 'axios';
 
 const ZERO = Buffer.alloc(32).toString('hex');
 
-export async function fetchBalances(
-  address: string,
-  blindPrivKey: string,
-  url: string
-) {
-  const utxoInterfaces = await fetchAndUnblindUtxos(
-    [{ confidentialAddress: address, blindingPrivateKey: blindPrivKey }],
-    url
-  );
-  return (utxoInterfaces as any).reduce(
-    (storage: { [x: string]: any }, item: { [x: string]: any; value: any }) => {
-      // get the first instance of the key by which we're grouping
-      var group = item['asset'];
-
-      // set `storage` for this instance of group to the outer scope (if not empty) or initialize it
-      storage[group] = storage[group] || 0;
-
-      // add this item to its group within `storage`
-      storage[group] += item.value;
-
-      // return the updated storage to the reduce function, which will then loop through the next
-      return storage;
-    },
-    {}
-  ); // {} is the initial value of the storage
-}
-
+/**
+ * Fetch the raw transaction by txid
+ * @param txId txID to fetch
+ * @param url esplora URL
+ */
 export async function fetchTxHex(txId: string, url: string): Promise<string> {
   return (await axios.get(`${url}/tx/${txId}/hex`)).data;
 }
 
+/**
+ * Fetch the transaction as TxInterface (with prevouts)
+ * @param txId transaction's hash to fetch
+ * @param url the esplora URL
+ */
 export async function fetchTx(txId: string, url: string): Promise<TxInterface> {
   return esploraTxToTxInterface(
     (await axios.get(`${url}/tx/${txId}`)).data,
@@ -53,6 +33,11 @@ export async function fetchTx(txId: string, url: string): Promise<TxInterface> {
   );
 }
 
+/**
+ * Fetch unspents for a given address.
+ * @param address
+ * @param url the esplora URL
+ */
 export async function fetchUtxos(
   address: string,
   url: string
@@ -60,271 +45,12 @@ export async function fetchUtxos(
   return (await axios.get(`${url}/address/${address}/utxo`)).data;
 }
 
-export async function fetchAndUnblindTxs(
-  addresses: string[],
-  blindingKeyGetter: BlindingKeyGetter,
-  explorerUrl: string,
-  skip?: (tx: TxInterface) => boolean
-): Promise<TxInterface[]> {
-  const generator = fetchAndUnblindTxsGenerator(
-    addresses,
-    blindingKeyGetter,
-    explorerUrl,
-    skip
-  );
-  const txs: Array<TxInterface> = [];
-
-  let iterator = await generator.next();
-  while (!iterator.done) {
-    txs.push(iterator.value);
-    iterator = await generator.next();
-  }
-
-  return txs;
-}
-
-export async function* fetchAndUnblindUtxosGenerator(
-  addressesAndBlindingKeys: Array<AddressInterface>,
-  url: string,
-  skip?: (utxo: UtxoInterface) => boolean
-): AsyncGenerator<UtxoInterface, number, undefined> {
-  let numberOfUtxos = 0;
-
-  // the generator repeats the process for each addresses
-  for (const {
-    confidentialAddress,
-    blindingPrivateKey,
-  } of addressesAndBlindingKeys) {
-    const blindedUtxos = await fetchUtxos(confidentialAddress, url);
-    const unblindedUtxosPromises = blindedUtxos.map((utxo: UtxoInterface) => {
-      if (skip && skip(utxo)) {
-        return utxo;
-      }
-
-      // this is a non blocking function, returning the base utxo if the unblind failed
-      return fetchPrevoutAndTryToUnblindUtxo(utxo, blindingPrivateKey, url);
-    });
-
-    // increase the number of utxos
-    numberOfUtxos += unblindedUtxosPromises.length;
-
-    // at each 'next' call, the generator will return the result of the next promise
-    for (const promise of unblindedUtxosPromises) {
-      const r = await promise;
-      yield r;
-    }
-  }
-
-  return numberOfUtxos;
-}
-
-export async function fetchAndUnblindUtxos(
-  addressesAndBlindingKeys: Array<AddressInterface>,
-  url: string,
-  skip?: (utxo: UtxoInterface) => boolean
-): Promise<UtxoInterface[]> {
-  const utxosGenerator = fetchAndUnblindUtxosGenerator(
-    addressesAndBlindingKeys,
-    url,
-    skip
-  );
-  const utxos: UtxoInterface[] = [];
-
-  let iterator = await utxosGenerator.next();
-  while (!iterator.done) {
-    utxos.push(iterator.value);
-    iterator = await utxosGenerator.next();
-  }
-
-  return utxos;
-}
-
 /**
- * Return an async generator fetching and unblinding addresses' transactions
- * @param addresses
- * @param blindingKeyGetter
+ * Convert an esplora transaction to a TxInterface
+ * @param esploraTx
  * @param explorerUrl
- * @param skip optional, can be used to skip certain transaction
  */
-export async function* fetchAndUnblindTxsGenerator(
-  addresses: string[],
-  blindingKeyGetter: BlindingKeyGetter,
-  explorerUrl: string,
-  skip?: (tx: TxInterface) => boolean
-): AsyncGenerator<TxInterface, void, undefined> {
-  const txids: string[] = [];
-  for (const address of addresses) {
-    const txsGenerator = fetchTxsGenerator(address, explorerUrl, skip);
-    let txIterator = await txsGenerator.next();
-    while (!txIterator.done) {
-      const tx = txIterator.value;
-      if (txids.includes(tx.txid)) {
-        txIterator = await txsGenerator.next();
-        continue;
-      }
-
-      try {
-        yield unblindTransaction(tx, blindingKeyGetter);
-        txids.push(tx.txid);
-      } catch (err) {
-        console.error(
-          `an error occurs during unblinding step for tx ${tx.txid}`
-        );
-      }
-      txIterator = await txsGenerator.next();
-    }
-  }
-  return;
-}
-
-/**
- * Fetch all the txs associated to a given address and unblind them using the blindingPrivateKey.
- * @param address the confidential address
- * @param explorerUrl the Esplora URL API using to fetch blockchain data.
- */
-async function* fetchTxsGenerator(
-  address: string,
-  explorerUrl: string,
-  skip?: (tx: TxInterface) => boolean
-): AsyncGenerator<TxInterface, number, undefined> {
-  let lastSeenTxid = undefined;
-  let newTxs: EsploraTx[] = [];
-  let numberOfTxs: number = 0;
-
-  do {
-    // fetch up to 25 txs
-    newTxs = await fetch25newestTxsForAddress(
-      address,
-      explorerUrl,
-      lastSeenTxid
-    );
-
-    if (newTxs.length === 0) break;
-    lastSeenTxid = newTxs[newTxs.length - 1].txid;
-    numberOfTxs += newTxs.length;
-
-    // convert them into txInterface
-    const txs: Promise<TxInterface>[] = newTxs.map(tx =>
-      esploraTxToTxInterface(tx, explorerUrl)
-    );
-
-    for (const tx of txs) {
-      const transaction = await tx;
-      if (skip && skip(transaction)) {
-        continue;
-      }
-      yield transaction;
-    }
-  } while (lastSeenTxid);
-
-  return numberOfTxs;
-}
-
-function txOutputToOutputInterface(
-  txOutput: TxOutput
-): BlindedOutputInterface | UnblindedOutputInterface {
-  if (isConfidentialOutput(txOutput)) {
-    const blindedOutput: BlindedOutputInterface = {
-      blindedAsset: txOutput.asset,
-      blindedValue: txOutput.value,
-      nonce: txOutput.nonce,
-      rangeProof: txOutput.rangeProof!,
-      surjectionProof: txOutput.surjectionProof!,
-      script: txOutput.script.toString('hex'),
-    };
-    return blindedOutput;
-  }
-
-  const unblindedOutput: UnblindedOutputInterface = {
-    asset: toAssetHash(txOutput.asset),
-    value: toNumber(txOutput.value),
-    script: txOutput.script.toString('hex'),
-    assetBlinder: ZERO,
-    valueBlinder: ZERO,
-  };
-
-  return unblindedOutput;
-}
-
-/**
- * takes the a TxInterface and try to transform BlindedOutputInterface to UnblindedOutputInterface (prevouts & outputs)
- * @param tx transaction to unblind
- * @param blindingPrivateKeys the privateKeys using to unblind the outputs.
- */
-export async function unblindTransaction(
-  tx: TxInterface,
-  blindingPrivateKeyGetter: BlindingKeyGetter
-): Promise<TxInterface> {
-  const promises: Promise<void>[] = [];
-
-  // try to unblind prevouts, if success replace blinded prevout by unblinded prevout
-  for (let inputIndex = 0; inputIndex < tx.vin.length; inputIndex++) {
-    const prevout = tx.vin[inputIndex].prevout;
-    if (isBlindedOutputInterface(prevout)) {
-      const promise = async () => {
-        const blindingKey = blindingPrivateKeyGetter(prevout.script);
-        if (blindingKey) {
-          const unblinded = await unblindOutput(prevout, blindingKey);
-          tx.vin[inputIndex].prevout = unblinded;
-        }
-      };
-
-      promises.push(promise());
-    }
-  }
-
-  // try to unblind outputs
-  for (let outputIndex = 0; outputIndex < tx.vout.length; outputIndex++) {
-    const output = tx.vout[outputIndex];
-    if (isBlindedOutputInterface(output)) {
-      const promise = async () => {
-        const blindingKey = blindingPrivateKeyGetter(output.script);
-        if (blindingKey) {
-          const unblinded = await unblindOutput(output, blindingKey);
-          tx.vout[outputIndex] = unblinded;
-        }
-      };
-
-      promises.push(promise());
-    }
-  }
-
-  await Promise.all(promises);
-
-  return tx;
-}
-
-export async function unblindOutput(
-  output: BlindedOutputInterface,
-  BlindingPrivateKey: string
-): Promise<UnblindedOutputInterface> {
-  const txOutput: TxOutput = {
-    asset: output.blindedAsset,
-    value: output.blindedValue,
-    rangeProof: output.rangeProof,
-    surjectionProof: output.surjectionProof,
-    nonce: output.nonce,
-    script: Buffer.from(output.script, 'hex'),
-  };
-
-  const blindPrivateKeyBuffer = Buffer.from(BlindingPrivateKey, 'hex');
-  const unblindedResult = await confidential.unblindOutputWithKey(
-    txOutput,
-    blindPrivateKeyBuffer
-  );
-
-  const unblindedOutput: UnblindedOutputInterface = {
-    asset: Buffer.from(unblindedResult.asset.reverse()).toString('hex'),
-    value: parseInt(unblindedResult.value, 10),
-    script: output.script,
-    assetBlinder: unblindedResult.assetBlindingFactor.toString('hex'),
-    valueBlinder: unblindedResult.valueBlindingFactor.toString('hex'),
-  };
-
-  return unblindedOutput;
-}
-
-async function esploraTxToTxInterface(
+export async function esploraTxToTxInterface(
   esploraTx: EsploraTx,
   explorerUrl: string
 ): Promise<TxInterface> {
@@ -375,79 +101,39 @@ async function esploraTxToTxInterface(
   return tx;
 }
 
-async function fetch25newestTxsForAddress(
-  address: string,
-  explorerUrl: string,
-  lastSeenTxid?: string
-): Promise<EsploraTx[]> {
-  let url = `${explorerUrl}/address/${address}/txs/chain`;
-  if (lastSeenTxid) {
-    url += `/${lastSeenTxid}`;
+// util function for output mapping
+function txOutputToOutputInterface(
+  txOutput: TxOutput
+): BlindedOutputInterface | UnblindedOutputInterface {
+  if (isConfidentialOutput(txOutput)) {
+    const blindedOutput: BlindedOutputInterface = {
+      blindedAsset: txOutput.asset,
+      blindedValue: txOutput.value,
+      nonce: txOutput.nonce,
+      rangeProof: txOutput.rangeProof!,
+      surjectionProof: txOutput.surjectionProof!,
+      script: txOutput.script.toString('hex'),
+    };
+    return blindedOutput;
   }
 
-  const response = await axios.get(url);
-  return response.data;
-}
+  const unblindedOutput: UnblindedOutputInterface = {
+    asset: toAssetHash(txOutput.asset),
+    value: toNumber(txOutput.value),
+    script: txOutput.script.toString('hex'),
+    assetBlinder: ZERO,
+    valueBlinder: ZERO,
+  };
 
-export async function utxoWithPrevout(
-  utxo: UtxoInterface,
-  explorerURL: string
-): Promise<UtxoInterface> {
-  const prevoutHex: string = await fetchTxHex(utxo.txid, explorerURL);
-  const prevout = Transaction.fromHex(prevoutHex).outs[utxo.vout];
-
-  return { ...utxo, prevout };
+  return unblindedOutput;
 }
 
 /**
- * try to unblind the utxo with blindPrivKey. if unblind fails, return utxo
- * if unblind step success: set prevout & unblindData members in UtxoInterface result
- * @param utxo utxo to unblind
- * @param blindPrivKey the blinding private key using to unblind
- * @param url esplora endpoint URL
+ * Create unblinded explorer URL from blinding data
+ * @param baseURL
+ * @param txID
+ * @param outputsBlinder
  */
-export async function fetchPrevoutAndTryToUnblindUtxo(
-  utxo: UtxoInterface,
-  blindPrivKey: string,
-  url: string
-): Promise<UtxoInterface> {
-  if (!utxo.prevout) utxo = await utxoWithPrevout(utxo, url);
-  try {
-    return unblindUtxo(utxo, blindPrivKey);
-  } catch (_) {
-    return utxo;
-  }
-}
-
-export async function unblindUtxo(
-  utxo: UtxoInterface,
-  blindPrivKey: string
-): Promise<UtxoInterface> {
-  if (!utxo.prevout)
-    throw new Error(
-      'utxo need utxo.prevout to be defined. Use utxoWithPrevout.'
-    );
-
-  if (!isConfidentialOutput(utxo.prevout)) {
-    return utxo;
-  }
-
-  const unblindData = await confidential.unblindOutputWithKey(
-    utxo.prevout,
-    Buffer.from(blindPrivKey, 'hex')
-  );
-
-  const unblindAsset = Buffer.alloc(32);
-  unblindData.asset.copy(unblindAsset);
-
-  return {
-    ...utxo,
-    asset: unblindAsset.reverse().toString('hex'),
-    value: parseInt(unblindData.value, 10),
-    unblindData,
-  };
-}
-
 export function makeUnblindURL(
   baseURL: string,
   txID: string,
@@ -467,6 +153,11 @@ export function makeUnblindURL(
   return `${baseURL}/tx/${txID}#blinded=${outputsString}`;
 }
 
+/**
+ * Create explorer URL with unblinding data
+ * @param tx transaction to create the link for
+ * @param baseURL base web Explorer URL
+ */
 export async function getUnblindURLFromTx(tx: TxInterface, baseURL: string) {
   const outputsData: Array<{
     value: number;

--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -163,8 +163,14 @@ export async function* fetchAndUnblindTxsGenerator(
         continue;
       }
 
-      txids.push(tx.txid);
-      yield unblindTransaction(tx, blindingKeyGetter);
+      try {
+        yield unblindTransaction(tx, blindingKeyGetter);
+        txids.push(tx.txid);
+      } catch (err) {
+        console.error(
+          `an error occurs during unblinding step for tx ${tx.txid}`
+        );
+      }
       txIterator = await txsGenerator.next();
     }
   }

--- a/src/explorer/transaction.ts
+++ b/src/explorer/transaction.ts
@@ -1,0 +1,182 @@
+import axios from 'axios';
+import {
+  BlindingKeyGetter,
+  isBlindedOutputInterface,
+  TxInterface,
+} from '../types';
+import { unblindOutput } from '../utils';
+import { esploraTxToTxInterface } from './esplora';
+import { EsploraTx } from './types';
+
+/**
+ * Return an async generator fetching and unblinding addresses' transactions
+ * @param addresses
+ * @param blindingKeyGetter
+ * @param explorerUrl
+ * @param skip optional, can be used to skip certain transaction
+ */
+export async function* fetchAndUnblindTxsGenerator(
+  addresses: string[],
+  blindingKeyGetter: BlindingKeyGetter,
+  explorerUrl: string,
+  skip?: (tx: TxInterface) => boolean
+): AsyncGenerator<TxInterface, void, undefined> {
+  const txids: string[] = [];
+  for (const address of addresses) {
+    const txsGenerator = fetchTxsGenerator(address, explorerUrl, skip);
+    let txIterator = await txsGenerator.next();
+    while (!txIterator.done) {
+      const tx = txIterator.value;
+      if (txids.includes(tx.txid)) {
+        txIterator = await txsGenerator.next();
+        continue;
+      }
+
+      try {
+        yield unblindTransaction(tx, blindingKeyGetter);
+        txids.push(tx.txid);
+      } catch (err) {
+        console.error(
+          `an error occurs during unblinding step for tx ${tx.txid}`
+        );
+      }
+      txIterator = await txsGenerator.next();
+    }
+  }
+  return;
+}
+
+/**
+ * Use FetchAndUnblindTxsGenerator to get all utxos for a set of addresses
+ * @param addresses
+ * @param blindingKeyGetter
+ * @param explorerUrl
+ * @param skip optional
+ */
+export async function fetchAndUnblindTxs(
+  addresses: string[],
+  blindingKeyGetter: BlindingKeyGetter,
+  explorerUrl: string,
+  skip?: (tx: TxInterface) => boolean
+): Promise<TxInterface[]> {
+  const generator = fetchAndUnblindTxsGenerator(
+    addresses,
+    blindingKeyGetter,
+    explorerUrl,
+    skip
+  );
+  const txs: Array<TxInterface> = [];
+
+  let iterator = await generator.next();
+  while (!iterator.done) {
+    txs.push(iterator.value);
+    iterator = await generator.next();
+  }
+
+  return txs;
+}
+
+/**
+ * Fetch all the txs associated to a given address and unblind them using the blindingPrivateKey.
+ * @param address the confidential address
+ * @param explorerUrl the Esplora URL API using to fetch blockchain data.
+ */
+async function* fetchTxsGenerator(
+  address: string,
+  explorerUrl: string,
+  skip?: (tx: TxInterface) => boolean
+): AsyncGenerator<TxInterface, number, undefined> {
+  let lastSeenTxid = undefined;
+  let newTxs: EsploraTx[] = [];
+  let numberOfTxs: number = 0;
+
+  do {
+    // fetch up to 25 txs
+    newTxs = await fetch25newestTxsForAddress(
+      address,
+      explorerUrl,
+      lastSeenTxid
+    );
+
+    if (newTxs.length === 0) break;
+    lastSeenTxid = newTxs[newTxs.length - 1].txid;
+    numberOfTxs += newTxs.length;
+
+    // convert them into txInterface
+    const txs: Promise<TxInterface>[] = newTxs.map(tx =>
+      esploraTxToTxInterface(tx, explorerUrl)
+    );
+
+    for (const tx of txs) {
+      const transaction = await tx;
+      if (skip && skip(transaction)) {
+        continue;
+      }
+      yield transaction;
+    }
+  } while (lastSeenTxid);
+
+  return numberOfTxs;
+}
+
+/**
+ * takes the a TxInterface and try to transform BlindedOutputInterface to UnblindedOutputInterface (prevouts & outputs)
+ * @param tx transaction to unblind
+ * @param blindingPrivateKeys the privateKeys using to unblind the outputs.
+ */
+export async function unblindTransaction(
+  tx: TxInterface,
+  blindingPrivateKeyGetter: BlindingKeyGetter
+): Promise<TxInterface> {
+  const promises: Promise<void>[] = [];
+
+  // try to unblind prevouts, if success replace blinded prevout by unblinded prevout
+  for (let inputIndex = 0; inputIndex < tx.vin.length; inputIndex++) {
+    const prevout = tx.vin[inputIndex].prevout;
+    if (isBlindedOutputInterface(prevout)) {
+      const promise = async () => {
+        const blindingKey = blindingPrivateKeyGetter(prevout.script);
+        if (blindingKey) {
+          const unblinded = await unblindOutput(prevout, blindingKey);
+          tx.vin[inputIndex].prevout = unblinded;
+        }
+      };
+
+      promises.push(promise());
+    }
+  }
+
+  // try to unblind outputs
+  for (let outputIndex = 0; outputIndex < tx.vout.length; outputIndex++) {
+    const output = tx.vout[outputIndex];
+    if (isBlindedOutputInterface(output)) {
+      const promise = async () => {
+        const blindingKey = blindingPrivateKeyGetter(output.script);
+        if (blindingKey) {
+          const unblinded = await unblindOutput(output, blindingKey);
+          tx.vout[outputIndex] = unblinded;
+        }
+      };
+
+      promises.push(promise());
+    }
+  }
+
+  await Promise.all(promises);
+
+  return tx;
+}
+
+async function fetch25newestTxsForAddress(
+  address: string,
+  explorerUrl: string,
+  lastSeenTxid?: string
+): Promise<EsploraTx[]> {
+  let url = `${explorerUrl}/address/${address}/txs/chain`;
+  if (lastSeenTxid) {
+    url += `/${lastSeenTxid}`;
+  }
+
+  const response = await axios.get(url);
+  return response.data;
+}

--- a/src/explorer/utxos.ts
+++ b/src/explorer/utxos.ts
@@ -1,0 +1,162 @@
+import { confidential, Transaction } from 'liquidjs-lib';
+import { AddressInterface, UtxoInterface } from '../types';
+import { fetchTxHex, fetchUtxos } from './esplora';
+import { isConfidentialOutput } from '../utils';
+
+/**
+ * Fetch balances for a given address
+ * @param address the address to fetch utxos
+ * @param blindPrivKey the blinding private key (if the address is confidential one)
+ * @param url esplora URL
+ */
+export async function fetchBalances(
+  address: string,
+  blindPrivKey: string,
+  url: string
+) {
+  const utxoInterfaces = await fetchAndUnblindUtxos(
+    [{ confidentialAddress: address, blindingPrivateKey: blindPrivKey }],
+    url
+  );
+  return (utxoInterfaces as any).reduce(
+    (storage: { [x: string]: any }, item: { [x: string]: any; value: any }) => {
+      // get the first instance of the key by which we're grouping
+      var group = item['asset'];
+
+      // set `storage` for this instance of group to the outer scope (if not empty) or initialize it
+      storage[group] = storage[group] || 0;
+
+      // add this item to its group within `storage`
+      storage[group] += item.value;
+
+      // return the updated storage to the reduce function, which will then loop through the next
+      return storage;
+    },
+    {}
+  ); // {} is the initial value of the storage
+}
+
+export async function* fetchAndUnblindUtxosGenerator(
+  addressesAndBlindingKeys: Array<AddressInterface>,
+  url: string,
+  skip?: (utxo: UtxoInterface) => boolean
+): AsyncGenerator<UtxoInterface, number, undefined> {
+  let numberOfUtxos = 0;
+
+  // the generator repeats the process for each addresses
+  for (const {
+    confidentialAddress,
+    blindingPrivateKey,
+  } of addressesAndBlindingKeys) {
+    const blindedUtxos = await fetchUtxos(confidentialAddress, url);
+    const unblindedUtxosPromises = blindedUtxos.map((utxo: UtxoInterface) => {
+      if (skip && skip(utxo)) {
+        return utxo;
+      }
+
+      // this is a non blocking function, returning the base utxo if the unblind failed
+      return fetchPrevoutAndTryToUnblindUtxo(utxo, blindingPrivateKey, url);
+    });
+
+    // increase the number of utxos
+    numberOfUtxos += unblindedUtxosPromises.length;
+
+    // at each 'next' call, the generator will return the result of the next promise
+    for (const promise of unblindedUtxosPromises) {
+      const r = await promise;
+      yield r;
+    }
+  }
+
+  return numberOfUtxos;
+}
+
+export async function fetchAndUnblindUtxos(
+  addressesAndBlindingKeys: Array<AddressInterface>,
+  url: string,
+  skip?: (utxo: UtxoInterface) => boolean
+): Promise<UtxoInterface[]> {
+  const utxosGenerator = fetchAndUnblindUtxosGenerator(
+    addressesAndBlindingKeys,
+    url,
+    skip
+  );
+  const utxos: UtxoInterface[] = [];
+
+  let iterator = await utxosGenerator.next();
+  while (!iterator.done) {
+    utxos.push(iterator.value);
+    iterator = await utxosGenerator.next();
+  }
+
+  return utxos;
+}
+
+/**
+ * Fetch utxo's prevout and set it
+ * @param utxo an unspent without prevout
+ * @param explorerURL esplora URL
+ */
+export async function utxoWithPrevout(
+  utxo: UtxoInterface,
+  explorerURL: string
+): Promise<UtxoInterface> {
+  const prevoutHex: string = await fetchTxHex(utxo.txid, explorerURL);
+  const prevout = Transaction.fromHex(prevoutHex).outs[utxo.vout];
+
+  return { ...utxo, prevout };
+}
+
+/**
+ * try to unblind the utxo with blindPrivKey. if unblind fails, return utxo
+ * if unblind step success: set prevout & unblindData members in UtxoInterface result
+ * @param utxo utxo to unblind
+ * @param blindPrivKey the blinding private key using to unblind
+ * @param url esplora endpoint URL
+ */
+export async function fetchPrevoutAndTryToUnblindUtxo(
+  utxo: UtxoInterface,
+  blindPrivKey: string,
+  url: string
+): Promise<UtxoInterface> {
+  if (!utxo.prevout) utxo = await utxoWithPrevout(utxo, url);
+  try {
+    return unblindUtxo(utxo, blindPrivKey);
+  } catch (_) {
+    return utxo;
+  }
+}
+
+/**
+ * Unblind utxo using hex encoded blinding private key
+ * @param utxo blinded utxo
+ * @param blindPrivKey blinding private key
+ */
+export async function unblindUtxo(
+  utxo: UtxoInterface,
+  blindPrivKey: string
+): Promise<UtxoInterface> {
+  if (!utxo.prevout)
+    throw new Error(
+      'utxo need utxo.prevout to be defined. Use utxoWithPrevout.'
+    );
+
+  if (!isConfidentialOutput(utxo.prevout)) {
+    return utxo;
+  }
+
+  const unblindData = await confidential.unblindOutputWithKey(
+    utxo.prevout,
+    Buffer.from(blindPrivKey, 'hex')
+  );
+
+  const unblindAsset = Buffer.alloc(32);
+  unblindData.asset.copy(unblindAsset);
+
+  return {
+    ...utxo,
+    asset: unblindAsset.reverse().toString('hex'),
+    value: parseInt(unblindData.value, 10),
+    unblindData,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export * from './coinselection/greedy';
 
 export * from './explorer/types';
 export * from './explorer/esplora';
+export * from './explorer/transaction';
+export * from './explorer/utxos';
 
 export * from './transaction';
 export * from './wallet';

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -9,7 +9,7 @@ import {
 } from './types';
 import { getNetwork, toOutpoint } from './utils';
 import { buildTx as buildTxFunction, BuildTxArgs } from './transaction';
-import { fetchAndUnblindUtxos } from './explorer/esplora';
+import { fetchAndUnblindUtxos } from './explorer/utxos';
 
 /**
  * Wallet abstraction.

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -12,8 +12,9 @@ import { buildTx, BuildTxArgs, decodePset } from '../src/transaction';
 import * as assert from 'assert';
 import { RecipientInterface } from '../src/types';
 import { greedyCoinSelector } from '../src/coinselection/greedy';
-import { fetchAndUnblindUtxos, fetchTxHex } from '../src/explorer/esplora';
+import { fetchTxHex } from '../src/explorer/esplora';
 import { psetToUnsignedHex } from '../src/utils';
+import { fetchAndUnblindUtxos } from '../src/explorer/utxos';
 
 jest.setTimeout(50000);
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -13,10 +13,8 @@ import {
   UnblindedOutputInterface,
   UtxoInterface,
 } from '../src/types';
-import {
-  fetchAndUnblindTxsGenerator,
-  fetchAndUnblindUtxosGenerator,
-} from '../src/explorer/esplora';
+import { fetchAndUnblindTxsGenerator } from '../src/explorer/transaction';
+import { fetchAndUnblindUtxosGenerator } from '../src/explorer/utxos';
 
 jest.setTimeout(500000);
 
@@ -107,7 +105,8 @@ describe('Wallet - Transaction builder', () => {
         utxoV = await utxosGenerator.next();
       }
 
-      assert.strictEqual(utxosArray.length, utxoV.value);
+      assert.strictEqual(utxosArray.length, utxoV.value.numberOfUtxos);
+      assert.strictEqual(utxoV.value.errors.length, 0);
     });
   });
 


### PR DESCRIPTION
This PR proposes a hotfix in order to "skip" if a transaction can't be unblinded. This lets to ignore "malware" transactions and so don't break tdex-app.

@tiero please review
