### PR TITLE
Add checkScript optional parameter in masterPubkey.getBlindingKeyPair method

### DIFF
--- a/src/identity/masterpubkey.ts
+++ b/src/identity/masterpubkey.ts
@@ -108,7 +108,7 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
     inputsBlindingDataLike?: Map<number, BlindingDataLike>
   ): Promise<string> {
     return super.blindPsetWithBlindKeysGetter(
-      (script: Buffer) => this.getBlindingKeyPair(script),
+      (script: Buffer) => this.getBlindingKeyPair(script, true),
       psetBase64,
       outputsToBlind,
       outputsPubKeys,
@@ -136,8 +136,18 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
    * @param scriptPubKey script to derive.
    */
   protected getBlindingKeyPair(
-    scriptPubKey: Buffer
+    scriptPubKey: Buffer,
+    checkScript: boolean = false
   ): { publicKey: Buffer; privateKey: Buffer } {
+    if (checkScript) {
+      const addressInterface = this.scriptToAddressCache.get(scriptPubKey);
+      if (!addressInterface) {
+        throw new Error(
+          `unknow blinding key for script ${scriptPubKey.toString('hex')}`
+        );
+      }
+    }
+
     const { publicKey, privateKey } = this.masterBlindingKeyNode.derive(
       scriptPubKey
     );

--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -101,7 +101,7 @@ export class Mnemonic extends MasterPublicKey implements IdentityInterface {
     inputsBlindingDataLike?: Map<number, BlindingDataLike>
   ): Promise<string> {
     return super.blindPsetWithBlindKeysGetter(
-      (script: Buffer) => super.getBlindingKeyPair(script),
+      (script: Buffer) => super.getBlindingKeyPair(script, true),
       psetBase64,
       outputsToBlind,
       outputsPubKeys,


### PR DESCRIPTION
This PR adds a check used in `blindPset` in order to throw an error if we try to blind a non-wallet output (only if we do not specify the blinding key) + unit test

@tiero please review