### PR TITLE
Fix unblind URL builder

### DIFF
--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -158,7 +158,7 @@ export function makeUnblindURL(
  * @param tx transaction to create the link for
  * @param baseURL base web Explorer URL
  */
-export async function getUnblindURLFromTx(tx: TxInterface, baseURL: string) {
+export function getUnblindURLFromTx(tx: TxInterface, baseURL: string) {
   const outputsData: Array<{
     value: number;
     asset: string;
@@ -166,9 +166,18 @@ export async function getUnblindURLFromTx(tx: TxInterface, baseURL: string) {
     valueBlinder: string;
   }> = [];
 
+  const reverseHex = (blinder: string) =>
+    Buffer.from(blinder, 'hex')
+      .reverse()
+      .toString('hex');
+
   for (const output of tx.vout) {
-    if (!isBlindedOutputInterface(output)) {
-      outputsData.push(output);
+    if (!isBlindedOutputInterface(output) && output.script.length > 0) {
+      outputsData.push({
+        ...output,
+        assetBlinder: reverseHex(output.assetBlinder),
+        valueBlinder: reverseHex(output.valueBlinder),
+      });
     }
   }
 


### PR DESCRIPTION
This PR adds two fixes in the `getUnblindURLFromTx` function:
1. does not include fee output 
2. reverse blinders bytes in the URL

tested :heavy_check_mark: 
example: https://blockstream.info/liquid/tx/1889bca2cfb8bfb13d48f96b71bf714a9a4030a42865a3de7ee4ef6e896fb0ba#blinded=48228827,ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2,17683bbed29ea7e4b74f7b82165e9e7490d434eb7995c5e0a1bec0e33bc9e8d8,8bbba8c055e5555d0c4c6226167dbf13562304d71b4549ce10505dfbea2ec087

@tiero please review