### PR TITLE
Add BrowserInject identity type and add Promise return type to IdentityInterface methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "bip39": "^3.0.3",
     "bs58check": "^2.1.2",
     "liquidjs-lib": "5.1.12",
+    "marina-provider": "^1.0.0",
     "slip77": "^0.1.1"
   }
 }

--- a/src/identity/browserinject.ts
+++ b/src/identity/browserinject.ts
@@ -1,0 +1,87 @@
+import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+import { MarinaProvider } from 'marina-provider';
+import { AddressInterface } from '../types';
+import Identity, {
+  IdentityInterface,
+  IdentityOpts,
+  IdentityType,
+} from './identity';
+
+/**
+ * This interface describes the shape of the value arguments used in contructor.
+ * @member windowProvider a valid property of the browser's window object where to lookup the injected provider
+ */
+export interface InjectOptsValue {
+  windowProvider: string;
+}
+
+/**
+ * A type guard function for InjectOptsValue
+ * @see InjectOptsValue
+ */
+function instanceOfInjectOptsValue(value: any): value is InjectOptsValue {
+  return 'windowProvider' in value;
+}
+
+export class BrowserInject extends Identity implements IdentityInterface {
+  // here we force MarinaProvider since there aren't other Liquid injected API specification available as TypeScript interface yet.
+  private provider: MarinaProvider;
+
+  // for inject, is restored always return true (there is only one address to generate)
+  readonly isRestored: Promise<boolean> = new Promise(() => true);
+
+  constructor(args: IdentityOpts) {
+    super(args);
+
+    // checks the args type.
+    if (args.type !== IdentityType.Inject) {
+      throw new Error('The identity arguments have not the Inject type.');
+    }
+
+    // checks if args.value is an instance of InjectOptsValue interface.
+    if (!instanceOfInjectOptsValue(args.value)) {
+      throw new Error(
+        'The value of IdentityOpts is not valid for Inject Identity.'
+      );
+    }
+
+    //checks if we are in the brower and if the provider is injected in the dom
+    if (
+      window === undefined ||
+      (window as any)[args.value.windowProvider] === undefined
+    ) {
+      throw new Error(
+        'The value.windowProvider of IdentityOpts is not valid or the script is to injected in the window'
+      );
+    }
+
+    this.provider = (window as any)[args.value.windowProvider];
+  }
+
+  getNextAddress(): AddressInterface | Promise<AddressInterface> {
+    return this.provider.getNextAddress();
+  }
+  getNextChangeAddress(): AddressInterface | Promise<AddressInterface> {
+    return this.provider.getNextChangeAddress();
+  }
+  signPset(psetBase64: string): string | Promise<string> {
+    return this.provider.signTransaction(psetBase64);
+  }
+  getAddresses(): AddressInterface[] | Promise<AddressInterface[]> {
+    return this.provider.getAddresses();
+  }
+  getBlindingPrivateKey(script: string): string {
+    throw new Error('Method not implemented.');
+  }
+  isAbleToSign(): boolean {
+    return true;
+  }
+  blindPset(
+    psetBase64: string,
+    outputsIndexToBlind: number[],
+    outputsPubKeysByIndex?: Map<number, string>,
+    inputsBlindingDataLike?: Map<number, BlindingDataLike>
+  ): Promise<string> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/identity/browserinject.ts
+++ b/src/identity/browserinject.ts
@@ -58,19 +58,19 @@ export class BrowserInject extends Identity implements IdentityInterface {
     this.provider = (window as any)[args.value.windowProvider];
   }
 
-  getNextAddress(): AddressInterface | Promise<AddressInterface> {
+  getNextAddress(): Promise<AddressInterface> {
     return this.provider.getNextAddress();
   }
-  getNextChangeAddress(): AddressInterface | Promise<AddressInterface> {
+  getNextChangeAddress(): Promise<AddressInterface> {
     return this.provider.getNextChangeAddress();
   }
-  signPset(psetBase64: string): string | Promise<string> {
+  signPset(psetBase64: string): Promise<string> {
     return this.provider.signTransaction(psetBase64);
   }
-  getAddresses(): AddressInterface[] | Promise<AddressInterface[]> {
+  getAddresses(): Promise<AddressInterface[]> {
     return this.provider.getAddresses();
   }
-  getBlindingPrivateKey(script: string): string {
+  getBlindingPrivateKey(script: string): Promise<string> {
     throw new Error('Method not implemented.');
   }
   isAbleToSign(): boolean {

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -38,10 +38,10 @@ export interface IdentityInterface {
   type: IdentityType;
   restorer: IdentityRestorerInterface;
   isRestored: Promise<boolean>;
-  getNextAddress(): AddressInterface;
-  getNextChangeAddress(): AddressInterface;
+  getNextAddress(): AddressInterface | Promise<AddressInterface>;
+  getNextChangeAddress(): AddressInterface | Promise<AddressInterface>;
   signPset(psetBase64: string): string | Promise<string>;
-  getAddresses(): AddressInterface[];
+  getAddresses(): AddressInterface[] | Promise<AddressInterface[]>;
   getBlindingPrivateKey(script: string): string;
   isAbleToSign(): boolean;
   blindPset(

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -42,7 +42,7 @@ export interface IdentityInterface {
   getNextChangeAddress(): AddressInterface | Promise<AddressInterface>;
   signPset(psetBase64: string): string | Promise<string>;
   getAddresses(): AddressInterface[] | Promise<AddressInterface[]>;
-  getBlindingPrivateKey(script: string): string;
+  getBlindingPrivateKey(script: string): string | Promise<string>;
   isAbleToSign(): boolean;
   blindPset(
     // the pset to blind

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,7 +2046,7 @@ bindings@^1.3.0, bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-"bip174@github:vulpemventures/bip174":
+bip174@vulpemventures/bip174.git:
   version "1.0.1"
   resolved "https://codeload.github.com/vulpemventures/bip174/tar.gz/d6a71254fa66b2ba84de80c67b7255ab65979c3b"
 
@@ -2094,9 +2094,9 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-"blech32@github:vulpemventures/blech32":
+blech32@vulpemventures/blech32.git:
   version "1.0.0"
-  resolved "https://codeload.github.com/vulpemventures/blech32/tar.gz/b42822d0496a27ed5a313395517e9029bcfccf2e"
+  resolved "https://codeload.github.com/vulpemventures/blech32/tar.gz/95595cf62f550905c3e312144f877c68ac128679"
 
 bluebird@^3.5.5:
   version "3.7.2"
@@ -5668,6 +5668,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+marina-provider@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.0.0.tgz#dbd9897db117cc35d31755b41b4ea7054b7a3035"
+  integrity sha512-hpZGcH5D0ZVwPtRvWlv5BUw69ZnoQc4iCEVTI7/eUZAqoaUUzyp7OpDY/UTLoaRWo++4mTKHtAGps8pGmD05jw==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
This adds a new `BrowserInject` identity of type `Inject` to the ldk project.

To do that, the IdentityInterface had been updated where some methods can return also a Promise, to allow the async nature of Browser extension and in the future of hardware wallets﻿. 


**NOTICE** the internal `provider` property of `BrowserInject` class is of type `MarinaProvider` for the reason that there aren't other TypeScript spec out there (yet) and alos we need to be sure we have those specific methods injected in the DOM to satisfy our internal Interface requirements.



