### PR TITLE
Identity interface returns promises

### DIFF
--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -38,11 +38,11 @@ export interface IdentityInterface {
   type: IdentityType;
   restorer: IdentityRestorerInterface;
   isRestored: Promise<boolean>;
-  getNextAddress(): AddressInterface | Promise<AddressInterface>;
-  getNextChangeAddress(): AddressInterface | Promise<AddressInterface>;
-  signPset(psetBase64: string): string | Promise<string>;
-  getAddresses(): AddressInterface[] | Promise<AddressInterface[]>;
-  getBlindingPrivateKey(script: string): string | Promise<string>;
+  getNextAddress(): Promise<AddressInterface>;
+  getNextChangeAddress(): Promise<AddressInterface>;
+  signPset(psetBase64: string): Promise<string>;
+  getAddresses(): Promise<AddressInterface[]>;
+  getBlindingPrivateKey(script: string): Promise<string>;
   isAbleToSign(): boolean;
   blindPset(
     // the pset to blind

--- a/src/identity/masterpubkey.ts
+++ b/src/identity/masterpubkey.ts
@@ -208,21 +208,21 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
     return newAddressGeneration;
   }
 
-  getNextAddress(): AddressInterface {
+  async getNextAddress(): Promise<AddressInterface> {
     const addr = this.getAddress(false, this.index);
     this.persistAddressToCache(addr);
     this.index += 1;
     return addr.address;
   }
 
-  getNextChangeAddress(): AddressInterface {
+  async getNextChangeAddress(): Promise<AddressInterface> {
     const addr = this.getAddress(true, this.changeIndex);
     this.persistAddressToCache(addr);
     this.changeIndex += 1;
     return addr.address;
   }
 
-  getBlindingPrivateKey(script: string): string {
+  async getBlindingPrivateKey(script: string): Promise<string> {
     const scriptPubKeyBuffer = Buffer.from(script, 'hex');
     return this.getBlindingKeyPair(scriptPubKeyBuffer).privateKey.toString(
       'hex'
@@ -236,7 +236,7 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
   }
 
   // returns all the addresses generated
-  getAddresses(): AddressInterface[] {
+  async getAddresses(): Promise<AddressInterface[]> {
     return this.scriptToAddressCache
       .values()
       .map(addrExtended => addrExtended.address);

--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -156,7 +156,7 @@ export class Mnemonic extends MasterPublicKey implements IdentityInterface {
   }
 
   // returns all the addresses generated
-  getAddresses(): AddressInterface[] {
+  async getAddresses(): Promise<AddressInterface[]> {
     return super.getAddresses();
   }
 }

--- a/src/identity/privatekey.ts
+++ b/src/identity/privatekey.ts
@@ -126,15 +126,15 @@ export class PrivateKey extends Identity implements IdentityInterface {
     };
   }
 
-  getNextAddress(): AddressInterface {
+  async getNextAddress(): Promise<AddressInterface> {
     return this.getAddress();
   }
 
-  getNextChangeAddress(): AddressInterface {
+  async getNextChangeAddress(): Promise<AddressInterface> {
     return this.getAddress();
   }
 
-  getBlindingPrivateKey(script: string): string {
+  async getBlindingPrivateKey(script: string): Promise<string> {
     const scriptPubKeyBuffer = Buffer.from(script, 'hex');
     if (!scriptPubKeyBuffer.equals(this.scriptPubKey)) {
       throw new Error('The script is not PrivateKey.scriptPubKey.');
@@ -175,7 +175,7 @@ export class PrivateKey extends Identity implements IdentityInterface {
   /**
    * for private key: only returns one confidential address & the associated blindingPrivKey.
    */
-  getAddresses(): AddressInterface[] {
+  async getAddresses(): Promise<AddressInterface[]> {
     return [
       {
         confidentialAddress: this.confidentialAddress,

--- a/test/fixtures/wallet.keys.ts
+++ b/test/fixtures/wallet.keys.ts
@@ -1,9 +1,6 @@
-import { networks, payments, ECPair, address } from 'liquidjs-lib';
+import { networks, payments, ECPair } from 'liquidjs-lib';
 import { PrivateKey } from '../../src/identity/privatekey';
 import { IdentityType } from '../../src/identity/identity';
-import { walletFromAddresses } from '../../src/wallet';
-import { BlindingKeyGetter } from '../../src/types';
-import { APIURL } from '../_regtest';
 
 const network = networks.regtest;
 // generate a random keyPair for bob
@@ -26,24 +23,6 @@ export const sender = new PrivateKey({
   },
 });
 
-export const senderBlindKeyGetter: BlindingKeyGetter = (script: string) => {
-  try {
-    return sender.getBlindingPrivateKey(script);
-  } catch (_) {
-    return undefined;
-  }
-};
-
-export const senderAddress = sender.getNextAddress().confidentialAddress;
-export const unconfidentialSenderAddress = address.fromConfidential(
-  senderAddress
-).unconfidentialAddress;
-export const senderBlindingKey = sender.getNextAddress().blindingPrivateKey;
-export const senderWallet = walletFromAddresses(
-  sender.getAddresses(),
-  APIURL,
-  'regtest'
-);
 // this is random address for who is receiving the withdrawal
 export const recipientAddress = payments.p2wpkh({
   pubkey: keyPair2.publicKey,

--- a/test/masterpubkey.identity.test.ts
+++ b/test/masterpubkey.identity.test.ts
@@ -98,25 +98,25 @@ describe('Identity: Master Pub Key', () => {
       });
     });
 
-    it('should return all the generated addresses', () => {
+    it('should return all the generated addresses', async () => {
       const pubKey = new MasterPublicKey(validOpts);
-      const addr0 = pubKey.getNextAddress();
-      const addr1 = pubKey.getNextAddress();
+      const addr0 = await pubKey.getNextAddress();
+      const addr1 = await pubKey.getNextAddress();
 
-      const addresses = pubKey.getAddresses();
+      const addresses = await pubKey.getAddresses();
 
       assert.deepStrictEqual(addresses.sort(), [addr0, addr1].sort());
     });
   });
 
   describe('MasterPubKey.getBlindingPrivateKey', () => {
-    it('should return privateKey according to slip77 spec', () => {
+    it('should return privateKey according to slip77 spec', async () => {
       const pubKey = new MasterPublicKey(validOpts);
 
       const {
         confidentialAddress,
         blindingPrivateKey,
-      } = pubKey.getNextAddress();
+      } = await pubKey.getNextAddress();
 
       const script: string = payments
         .p2wpkh({
@@ -126,7 +126,7 @@ describe('Identity: Master Pub Key', () => {
         .output!.toString('hex');
 
       assert.deepStrictEqual(
-        pubKey.getBlindingPrivateKey(script),
+        await pubKey.getBlindingPrivateKey(script),
         blindingPrivateKey
       );
     });
@@ -141,8 +141,8 @@ describe('Identity: Master Pub Key', () => {
       pubkey = new MasterPublicKey(validOpts);
       // faucet all the addresses
       for (let i = 0; i < numberOfAddresses; i++) {
-        const addr = pubkey.getNextAddress();
-        const changeAddr = pubkey.getNextChangeAddress();
+        const addr = await pubkey.getNextAddress();
+        const changeAddr = await pubkey.getNextChangeAddress();
         await faucet(addr.confidentialAddress);
         await faucet(changeAddr.confidentialAddress);
       }
@@ -156,25 +156,20 @@ describe('Identity: Master Pub Key', () => {
       await toRestorePubKey.isRestored;
     });
 
-    it('should restore already used addresses', () => {
+    it('should restore already used addresses', async () => {
+      const pubKeyAddrs = await pubkey.getAddresses();
+      const toRestoreAddrs = await toRestorePubKey.getAddresses();
       assert.deepStrictEqual(
-        pubkey
-          .getAddresses()
-          .map(a => a.confidentialAddress)
-          .sort(),
-        toRestorePubKey
-          .getAddresses()
-          .map(a => a.confidentialAddress)
-          .sort()
+        pubKeyAddrs.map(a => a.confidentialAddress).sort(),
+        toRestoreAddrs.map(a => a.confidentialAddress).sort()
       );
     });
 
-    it('should update the index when restored', () => {
-      const addressesKnown = toRestorePubKey
-        .getAddresses()
-        .map(a => a.confidentialAddress);
+    it('should update the index when restored', async () => {
+      const addrs = await toRestorePubKey.getAddresses();
+      const addressesKnown = addrs.map(a => a.confidentialAddress);
 
-      const next = toRestorePubKey.getNextAddress();
+      const next = await toRestorePubKey.getNextAddress();
       const nextIsAlreadyKnown = addressesKnown.includes(
         next.confidentialAddress
       );
@@ -182,12 +177,11 @@ describe('Identity: Master Pub Key', () => {
       assert.deepStrictEqual(nextIsAlreadyKnown, false);
     });
 
-    it('should update the change index when restored', () => {
-      const addressesKnown = toRestorePubKey
-        .getAddresses()
-        .map(a => a.confidentialAddress);
+    it('should update the change index when restored', async () => {
+      const addrs = await toRestorePubKey.getAddresses();
+      const addressesKnown = addrs.map(a => a.confidentialAddress);
 
-      const next = toRestorePubKey.getNextChangeAddress();
+      const next = await toRestorePubKey.getNextChangeAddress();
       const nextIsAlreadyKnown = addressesKnown.includes(
         next.confidentialAddress
       );

--- a/test/privatekey.identity.test.ts
+++ b/test/privatekey.identity.test.ts
@@ -135,9 +135,9 @@ describe('Identity: Private key', () => {
   });
 
   describe('PrivateKey.getAddresses', () => {
-    it("should return the PrivateKey instance p2wpkh's address and blindPrivKey", () => {
+    it("should return the PrivateKey instance p2wpkh's address and blindPrivKey", async () => {
       const privateKey = new PrivateKey(validOpts);
-      const addr: AddressInterface = privateKey.getAddresses()[0];
+      const addr: AddressInterface = (await privateKey.getAddresses())[0];
       assert.deepStrictEqual(
         p2wpkh.confidentialAddress,
         addr.confidentialAddress
@@ -150,12 +150,11 @@ describe('Identity: Private key', () => {
   });
 
   describe('PrivateKey.getBlindingPrivateKey', () => {
-    it('should return the private blinding key associated with the PrivateKey instance confidential address', () => {
+    it('should return the private blinding key associated with the PrivateKey instance confidential address', async () => {
       const privateKey = new PrivateKey(validOpts);
-      const {
-        confidentialAddress,
-        blindingPrivateKey,
-      } = privateKey.getAddresses()[0];
+      const { confidentialAddress, blindingPrivateKey } = (
+        await privateKey.getAddresses()
+      )[0];
       const script: string = payments
         .p2wpkh({
           confidentialAddress,
@@ -163,7 +162,7 @@ describe('Identity: Private key', () => {
         })
         .output!.toString('hex');
       assert.deepStrictEqual(
-        privateKey.getBlindingPrivateKey(script),
+        await privateKey.getBlindingPrivateKey(script),
         blindingPrivateKey
       );
     });
@@ -171,7 +170,7 @@ describe('Identity: Private key', () => {
     it('should throw an error if the script is not the PrivateKey scriptPubKey', () => {
       const privateKey = new PrivateKey(validOpts);
       const notTheGoodScript = 'bbb4659bedb5d3d3c7ab12d7f85323c3a1b6c060efbe';
-      assert.throws(() => privateKey.getBlindingPrivateKey(notTheGoodScript));
+      assert.rejects(() => privateKey.getBlindingPrivateKey(notTheGoodScript));
     });
   });
 });

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -1,12 +1,6 @@
 import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
 import { networks, Psbt, Transaction } from 'liquidjs-lib';
-import {
-  recipientAddress,
-  senderAddress,
-  senderWallet,
-  sender,
-  senderBlindingKey,
-} from './fixtures/wallet.keys';
+import { recipientAddress, sender } from './fixtures/wallet.keys';
 import { APIURL, broadcastTx, faucet, mint } from './_regtest';
 import { buildTx, BuildTxArgs, decodePset } from '../src/transaction';
 import * as assert from 'assert';
@@ -15,14 +9,29 @@ import { greedyCoinSelector } from '../src/coinselection/greedy';
 import { fetchTxHex } from '../src/explorer/esplora';
 import { psetToUnsignedHex } from '../src/utils';
 import { fetchAndUnblindUtxos } from '../src/explorer/utxos';
+import { walletFromAddresses, WalletInterface } from '../src';
 
 jest.setTimeout(50000);
+
+let senderWallet: WalletInterface;
 
 describe('buildTx', () => {
   let USDT: string = '';
   let args: BuildTxArgs;
+  let senderAddress: string = '';
+  let senderBlindingKey: string = '';
 
   beforeAll(async () => {
+    const addrI = await sender.getNextAddress();
+    senderAddress = addrI.confidentialAddress;
+    senderBlindingKey = addrI.blindingPrivateKey;
+
+    senderWallet = await walletFromAddresses(
+      await sender.getAddresses(),
+      APIURL,
+      'regtest'
+    );
+
     await faucet(senderAddress);
     // mint and fund with USDT
     const minted = await mint(senderAddress, 100);


### PR DESCRIPTION
This PR simplifies the `IdentityInterface`: all the methods now return `Promises`. 

- Change the `IdentityInterface` declaration.
- Update all the "sync" implementation : `Mnemonic`, `PrivateKey` & `MasterPubKey`.
- Update all the tests (some needs to be async now).

it includes **breaking changes**.

@tiero please review