### PR TITLE
improve fetchAndUnblindUtxos + add test for wrong private key

### DIFF
--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -1,4 +1,4 @@
-import { address } from 'liquidjs-lib';
+import { address, ECPair } from 'liquidjs-lib';
 import { UtxoInterface } from './../dist/types.d';
 import * as assert from 'assert';
 import {
@@ -42,6 +42,19 @@ describe('esplora', () => {
 
       const withPrevouts = senderUtxos.filter(u => u.prevout);
       assert.deepStrictEqual(withPrevouts.length, senderUtxos.length);
+    });
+
+    it('should fetch the utxos, even if wrong blinding key is provided', async () => {
+      const senderUtxos = await fetchAndUnblindUtxos(
+        [
+          {
+            confidentialAddress: senderAddress.confidentialAddress,
+            blindingPrivateKey: ECPair.makeRandom().privateKey!.toString('hex'),
+          },
+        ],
+        APIURL
+      );
+      assert.deepStrictEqual(senderUtxos.length, 0);
     });
 
     it('should unblind utxos if the blinding key is provided', async () => {


### PR DESCRIPTION
This PR aims to fix a set of bugs happening during the `fetchAndUnblindUtxos` unblinding step.

- `fetchAndUnblindUtxos` now run unblind tasks in sequence instead of as a set of promises.
-  now we check the relation between confidential address & blinding private key given as parameters.
- add a test case with an invalid address/blindPrivKey.

@tiero please review