### PR TITLE
Support P2SH/P2WSH utxos

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export interface UtxoInterface {
   value?: number;
   prevout?: TxOutput;
   unblindData?: confidential.UnblindOutputResult;
+  redeemScript?: Buffer;
+  witnessScript?: Buffer;
 }
 
 export interface BlindedOutputInterface {


### PR DESCRIPTION
This adds 2 new props `redeemScript` and `witnessScript` to the `UtxoInterface` in order to support handling inputs of type P2SH or P2WSH. For these input types, the relative partial inputs require redeem or witness script to not be null.

Please @tiero review this