### PR TITLE
[fix] catch and return unblindErrors if any unblinding step has failed

### DIFF
--- a/src/error/unblind-error.ts
+++ b/src/error/unblind-error.ts
@@ -1,0 +1,7 @@
+export default class UnblindError extends Error {
+  constructor(txid: string, vout: number, blindingKey: string) {
+    super(
+      `UnblindError output (${txid}:${vout}) with blind key ${blindingKey}`
+    );
+  }
+}

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -105,7 +105,7 @@ describe('esplora', () => {
         senderAddress.blindingPrivateKey,
         APIURL
       );
-      expect(utxoInterface).toMatchObject({
+      expect(utxoInterface.unblindedUtxo).toMatchObject({
         asset: expect.any(String),
         assetcommitment: expect.any(String),
         noncecommitment: expect.any(String),

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -119,7 +119,7 @@ describe('Wallet - Transaction builder', () => {
       }
 
       assert.strictEqual(utxosArray.length, utxoV.value.numberOfUtxos);
-      assert.strictEqual(utxoV.value.errors.length, 0);
+      assert.strictEqual(utxoV.value.errors.filter(e => e).length, 0);
     });
   });
 


### PR DESCRIPTION
This PR add a ` try { } catch` statement in `fetchAndUnblindTxsGenerator` and `fetchAndUnblindUtxosGenerator`. It aims to ignore unblinding errors (via `UnblindError` object).

Breaking change for `fetchPrevoutAndTryToUnblindUtxo` function.

@tiero please review

it closes #56 