### PR TITLE
[hotfix] Mnemonic restoration

### DIFF
--- a/src/identity/masterpubkey.ts
+++ b/src/identity/masterpubkey.ts
@@ -309,7 +309,7 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
         // generate addresses to test
         const addressesToTest = await this.generateSetOfAddresses(
           index,
-          NOT_USED_ADDRESSES_LIMIT - counter,
+          NOT_USED_ADDRESSES_LIMIT,
           change
         );
         // test all addresses asynchronously using restorer.


### PR DESCRIPTION
generate addresses in batches of 20 (GAP_LIMIT) to ensure that all addresses are tested.

@tiero please review