### PR TITLE
Prevent generating addresses if none has been used

### DIFF
--- a/src/identity/browserinject.ts
+++ b/src/identity/browserinject.ts
@@ -1,4 +1,5 @@
 import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+// @ts-ignore
 import { MarinaProvider } from 'marina-provider';
 import { AddressInterface } from '../types';
 import Identity, {

--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -22,7 +22,7 @@ function restorerFromEsplora<R extends MasterPublicKey>(
     gapLimit = 20,
   }) => {
     const restoreFunc = async function(
-      nextAddrFunc: (index?: number) => string | undefined
+      nextAddrFunc: (index: number) => string
     ): Promise<number | undefined> {
       let counter = 0;
       let index = 0;
@@ -30,7 +30,6 @@ function restorerFromEsplora<R extends MasterPublicKey>(
 
       while (counter < gapLimit) {
         const addr = nextAddrFunc(index);
-        if (addr === undefined) break;
         const addrHasTxs = await addressHasBeenUsed(addr, esploraURL);
         if (addrHasTxs) {
           maxIndex = index;
@@ -43,20 +42,12 @@ function restorerFromEsplora<R extends MasterPublicKey>(
       return maxIndex;
     };
 
-    const lastUsedExternalIndex = await restoreFunc((index?: number) => {
-      if (index !== undefined) {
-        return identity.getAddress(false, index).address.confidentialAddress;
-      } else {
-        return undefined;
-      }
+    const lastUsedExternalIndex = await restoreFunc((index: number) => {
+      return identity.getAddress(false, index).address.confidentialAddress;
     });
 
-    const lastUsedInternalIndex = await restoreFunc((index?: number) => {
-      if (index !== undefined) {
-        return identity.getAddress(true, index).address.confidentialAddress;
-      } else {
-        return undefined;
-      }
+    const lastUsedInternalIndex = await restoreFunc((index: number) => {
+      return identity.getAddress(true, index).address.confidentialAddress;
     });
 
     return restorerFromState(identity)({

--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -87,27 +87,31 @@ export function masterPubKeyRestorerFromEsplora(toRestore: MasterPublicKey) {
 // From state
 
 export interface StateRestorerOpts {
-  lastUsedExternalIndex: number;
-  lastUsedInternalIndex: number;
+  lastUsedExternalIndex?: number;
+  lastUsedInternalIndex?: number;
 }
 
 function restorerFromState<R extends MasterPublicKey>(
   identity: R
 ): Restorer<StateRestorerOpts, R> {
   return async ({ lastUsedExternalIndex, lastUsedInternalIndex }) => {
-    for (let i = 0; i < lastUsedExternalIndex + 1; i++) {
-      const address = await identity.getNextAddress();
-      const index = getIndexFromAddress(address);
-      if (index >= lastUsedExternalIndex) {
-        break;
+    if (lastUsedExternalIndex !== undefined) {
+      for (let i = 0; i < lastUsedExternalIndex + 1; i++) {
+        const address = await identity.getNextAddress();
+        const index = getIndexFromAddress(address);
+        if (index >= lastUsedExternalIndex) {
+          break;
+        }
       }
     }
 
-    for (let i = 0; i < lastUsedInternalIndex + 1; i++) {
-      const address = await identity.getNextChangeAddress();
-      const index = getIndexFromAddress(address);
-      if (index >= lastUsedInternalIndex) {
-        break;
+    if (lastUsedInternalIndex !== undefined) {
+      for (let i = 0; i < lastUsedInternalIndex + 1; i++) {
+        const address = await identity.getNextChangeAddress();
+        const index = getIndexFromAddress(address);
+        if (index >= lastUsedInternalIndex) {
+          break;
+        }
       }
     }
 

--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -43,25 +43,21 @@ function restorerFromEsplora<R extends MasterPublicKey>(
       return maxIndex;
     };
 
-    const lastUsedExternalIndex = await restoreFunc(
-      (index?: number) => {
-        if (index !== undefined) {
-          return identity.getAddress(false, index).address.confidentialAddress
-        } else {
-          return undefined
-        }
+    const lastUsedExternalIndex = await restoreFunc((index?: number) => {
+      if (index !== undefined) {
+        return identity.getAddress(false, index).address.confidentialAddress;
+      } else {
+        return undefined;
       }
-    );
+    });
 
-    const lastUsedInternalIndex = await restoreFunc(
-      (index?: number) => {
-        if (index !== undefined) {
-          return identity.getAddress(true, index).address.confidentialAddress
-        } else {
-          return undefined
-        }
+    const lastUsedInternalIndex = await restoreFunc((index?: number) => {
+      if (index !== undefined) {
+        return identity.getAddress(true, index).address.confidentialAddress;
+      } else {
+        return undefined;
       }
-    );
+    });
 
     return restorerFromState(identity)({
       lastUsedExternalIndex,

--- a/test/mnemonic.identity.test.ts
+++ b/test/mnemonic.identity.test.ts
@@ -400,6 +400,51 @@ describe('Identity: Mnemonic', () => {
           "m/84'/0'/0'/1/5"
         );
       });
+
+      it('should update indexes when no internalIndex', async () => {
+        const restored = await restorer({
+          lastUsedExternalIndex: 10,
+        });
+        assert.deepStrictEqual(
+          (await restored.getNextAddress()).derivationPath,
+          "m/84'/0'/0'/0/11"
+        );
+        assert.deepStrictEqual(
+          (await restored.getNextChangeAddress()).derivationPath,
+          "m/84'/0'/0'/1/0"
+        );
+      });
+
+      it('should update indexes when no externalIndex', async () => {
+        const restored = await restorer({
+          lastUsedInternalIndex: 10,
+        });
+        assert.deepStrictEqual(
+          (await restored.getNextAddress()).derivationPath,
+          "m/84'/0'/0'/0/0"
+        );
+        assert.deepStrictEqual(
+          (await restored.getNextChangeAddress()).derivationPath,
+          "m/84'/0'/0'/1/11"
+        );
+      });
+
+      it('should update indexes when no internalIndex and externalIndex', async () => {
+        const restored = await restorer({});
+        assert.deepStrictEqual(
+          (await restored.getNextAddress()).derivationPath,
+          "m/84'/0'/0'/0/0"
+        );
+        assert.deepStrictEqual(
+          (await restored.getNextChangeAddress()).derivationPath,
+          "m/84'/0'/0'/1/0"
+        );
+      });
+
+      it('should not return addresses when no internalIndex and externalIndex', async () => {
+        const restored = await restorer({});
+        assert.deepStrictEqual(await restored.getAddresses(), []);
+      });
     });
   });
 });


### PR DESCRIPTION
Fix bug where it generates addresses 0/0 and 1/0 even when seed is new.
It closes #64 

Make StateRestorerOpts properties optional for the case where seed is new and no addresses have been found.

Please review @tiero @louisinger 