### PR TITLE
Optimize restorers

### DIFF
--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -28,10 +28,11 @@ function restorerFromEsplora<R extends MasterPublicKey>(
       let maxIndex: number | undefined = undefined;
 
       while (counter < gapLimit) {
+        const cpyNext = next;
         // generate a set of addresses from next to (next + gapLimit - 1)
         const addrs = await Promise.all(
           Array.from(Array(gapLimit).keys())
-            .map(i => i + next)
+            .map(i => i + cpyNext)
             .map(getAddrFunc)
         );
 

--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -2,7 +2,6 @@ import { MasterPublicKey } from './../identity/masterpubkey';
 import { Mnemonic } from './../identity/mnemonic';
 import { Restorer } from './restorer';
 import axios from 'axios';
-import { getIndexFromAddress } from '../utils';
 
 // from Esplora
 
@@ -22,33 +21,58 @@ function restorerFromEsplora<R extends MasterPublicKey>(
     gapLimit = 20,
   }) => {
     const restoreFunc = async function(
-      nextAddrFunc: (index: number) => string
+      getAddrFunc: (index: number) => Promise<string>
     ): Promise<number | undefined> {
       let counter = 0;
-      let index = 0;
-      let maxIndex = undefined;
+      let next = 0;
+      let maxIndex: number | undefined = undefined;
 
       while (counter < gapLimit) {
-        const addr = nextAddrFunc(index);
-        const addrHasTxs = await addressHasBeenUsed(addr, esploraURL);
-        if (addrHasTxs) {
-          maxIndex = index;
-          counter = 0;
-        } else {
-          counter++;
+        // generate a set of addresses from next to (next + gapLimit - 1)
+        const addrs = await Promise.all(
+          Array.from(Array(gapLimit).keys())
+            .map(i => i + next)
+            .map(getAddrFunc)
+        );
+
+        const hasBeenUsedArray = await Promise.all(
+          addrs.map(a => addressHasBeenUsed(a, esploraURL))
+        );
+
+        let indexInArray = 0;
+        for (const hasBeenUsed of hasBeenUsedArray) {
+          if (hasBeenUsed) {
+            maxIndex = indexInArray + next;
+            counter = 0;
+          } else {
+            counter++;
+            if (counter === gapLimit) return maxIndex; // duplicate the stop condition
+          }
+          indexInArray++;
         }
-        index++;
+
+        next += gapLimit; // increase next
       }
+
       return maxIndex;
     };
 
-    const lastUsedExternalIndex = await restoreFunc((index: number) => {
-      return identity.getAddress(false, index).address.confidentialAddress;
+    const restorerExternal = restoreFunc((index: number) => {
+      return Promise.resolve(
+        identity.getAddress(false, index).address.confidentialAddress
+      );
     });
 
-    const lastUsedInternalIndex = await restoreFunc((index: number) => {
-      return identity.getAddress(true, index).address.confidentialAddress;
+    const restorerInternal = restoreFunc((index: number) => {
+      return Promise.resolve(
+        identity.getAddress(true, index).address.confidentialAddress
+      );
     });
+
+    const [lastUsedExternalIndex, lastUsedInternalIndex] = await Promise.all([
+      restorerExternal,
+      restorerInternal,
+    ]);
 
     return restorerFromState(identity)({
       lastUsedExternalIndex,
@@ -92,25 +116,23 @@ function restorerFromState<R extends MasterPublicKey>(
   identity: R
 ): Restorer<StateRestorerOpts, R> {
   return async ({ lastUsedExternalIndex, lastUsedInternalIndex }) => {
+    const promises = [];
+
     if (lastUsedExternalIndex !== undefined) {
-      for (let i = 0; i < lastUsedExternalIndex + 1; i++) {
-        const address = await identity.getNextAddress();
-        const index = getIndexFromAddress(address);
-        if (index >= lastUsedExternalIndex) {
-          break;
-        }
+      for (let i = 0; i <= lastUsedExternalIndex; i++) {
+        const promise = identity.getNextAddress();
+        promises.push(promise);
       }
     }
 
     if (lastUsedInternalIndex !== undefined) {
-      for (let i = 0; i < lastUsedInternalIndex + 1; i++) {
-        const address = await identity.getNextChangeAddress();
-        const index = getIndexFromAddress(address);
-        if (index >= lastUsedInternalIndex) {
-          break;
-        }
+      for (let i = 0; i <= lastUsedInternalIndex; i++) {
+        const promise = identity.getNextChangeAddress();
+        promises.push(promise);
       }
     }
+
+    await Promise.all(promises);
 
     return identity;
   };

--- a/test/mnemonic.identity.test.ts
+++ b/test/mnemonic.identity.test.ts
@@ -419,6 +419,7 @@ describe('Identity: Mnemonic', () => {
         const restored = await restorer({
           lastUsedInternalIndex: 10,
         });
+
         assert.deepStrictEqual(
           (await restored.getNextAddress()).derivationPath,
           "m/84'/0'/0'/0/0"


### PR DESCRIPTION
**This PR uses `Promise.all` at every steps in restorers. It lets to reduce a lot the time to restore wallet's addresses.**

this is not a breaking change.

it closes #68 

@tiero please review