### PR TITLE
Don't fetch mainchain pegin tx from Liquid Esplora

### DIFF
--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -58,8 +58,10 @@ export async function esploraTxToTxInterface(
   const inputVouts: number[] = [];
 
   for (const input of esploraTx.vin) {
-    inputTxIds.push(input.txid);
-    inputVouts.push(input.vout);
+    if (!input.is_pegin) {
+      inputTxIds.push(input.txid);
+      inputVouts.push(input.vout);
+    }
   }
 
   const prevoutTxHexs = await Promise.all(


### PR DESCRIPTION
Check that transaction input is not a pegin to prevent fetching mainchain pegin tx from Liquid Esplora.

Please review @tiero @louisinger 