### PR TITLE
hotfix pegin tx from esplora

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,8 @@ export interface UnblindedOutputInterface {
 export interface InputInterface {
   txid: string;
   vout: number;
-  prevout: BlindedOutputInterface | UnblindedOutputInterface;
+  prevout?: BlindedOutputInterface | UnblindedOutputInterface;
+  isPegin: boolean;
 }
 
 export interface TxInterface {


### PR DESCRIPTION
**This PR is a hotfix for pegin transactions returned by generators.**

`InputInterface` is now returned in case of `is_pegin =true` in EsploraTx. 

it closes #74 
@Janaka-Steph please review