### PR TITLE
Custom error handling in CoinSelector (substract fee scenario) + `sendTx` in wallet

### DIFF
--- a/src/coinselection/coinSelector.ts
+++ b/src/coinselection/coinSelector.ts
@@ -2,6 +2,7 @@ import {
   UtxoInterface,
   RecipientInterface,
   ChangeAddressFromAssetGetter,
+  CoinSelectorErrorFn,
 } from './../types';
 
 export interface CoinSelectionResult {
@@ -10,6 +11,8 @@ export interface CoinSelectionResult {
 }
 
 export type CoinSelector = (
+  errorHandler: CoinSelectorErrorFn
+) => (
   unspents: UtxoInterface[],
   outputs: RecipientInterface[],
   changeGetter: ChangeAddressFromAssetGetter

--- a/src/coinselection/greedy.ts
+++ b/src/coinselection/greedy.ts
@@ -3,53 +3,40 @@ import {
   RecipientInterface,
   UtxoInterface,
   CompareUtxoFn,
-  HandleCoinSelectorErrorFn,
 } from './../types';
 import { CoinSelectionResult, CoinSelector } from './coinSelector';
 import {
-  checkCoinSelect,
   coinSelect,
   makeChanges,
   reduceRecipients,
+  throwErrorHandler,
 } from './utils';
 
 const defaultCompareFn: CompareUtxoFn = (a: UtxoInterface, b: UtxoInterface) =>
   a.value! - b.value!;
-
-// the exported factory function for greedy coin selector
-export function greedyCoinSelector(
-  compare: CompareUtxoFn = defaultCompareFn
-): CoinSelector {
-  const errorHandler = (asset: string) => {
-    throw new Error(`coin selector error: ${asset}`);
-  };
-  return greedyCoinSelection(compare)(errorHandler);
-}
 
 /**
  * select utxo for outputs among unspents.
  * @param unspents a set of unspents.
  * @param outputs the outputs targetted by the coin selection
  */
-const greedyCoinSelection = (sortFn: CompareUtxoFn) => (
-  errorHandler: HandleCoinSelectorErrorFn
-) => (
-  unspents: UtxoInterface[],
-  recipients: RecipientInterface[],
-  changeAddressGetter: ChangeAddressFromAssetGetter
-): CoinSelectionResult => {
-  const coinSelectFn = coinSelect(sortFn)(errorHandler)(unspents);
-  const makeChangesFn = makeChanges(changeAddressGetter);
+export function greedyCoinSelector(sortFn = defaultCompareFn): CoinSelector {
+  return (errorHandler = throwErrorHandler) => {
+    const coinSelectFn = coinSelect(sortFn)(errorHandler);
+    return (
+      unspents: UtxoInterface[],
+      recipients: RecipientInterface[],
+      changeAddressGetter: ChangeAddressFromAssetGetter
+    ): CoinSelectionResult => {
+      const makeChangesFn = makeChanges(changeAddressGetter);
+      const recipientsMap = reduceRecipients(recipients);
+      const selectedUtxos = coinSelectFn(unspents)(recipientsMap);
+      const changeOutputs = makeChangesFn(recipientsMap)(selectedUtxos);
 
-  const recipientsMap = reduceRecipients(recipients);
-  const selectedUtxos = coinSelectFn(recipientsMap);
-  const changeOutputs = makeChangesFn(recipientsMap)(selectedUtxos);
-
-  // check that input amount = output amount and input assets = output assets
-  checkCoinSelect([...recipients, ...changeOutputs])(selectedUtxos);
-
-  return {
-    selectedUtxos,
-    changeOutputs,
+      return {
+        selectedUtxos,
+        changeOutputs,
+      };
+    };
   };
-};
+}

--- a/src/coinselection/greedy.ts
+++ b/src/coinselection/greedy.ts
@@ -1,12 +1,12 @@
-import { isBlindedUtxo } from '../utils';
 import {
   ChangeAddressFromAssetGetter,
   RecipientInterface,
   UtxoInterface,
+  CompareUtxoFn,
+  HandleCoinSelectorErrorFn,
 } from './../types';
 import { CoinSelectionResult, CoinSelector } from './coinSelector';
-
-export type CompareUtxoFn = (a: UtxoInterface, b: UtxoInterface) => number;
+import { coinSelect, makeChanges, reduceRecipients } from './utils';
 
 const defaultCompareFn: CompareUtxoFn = (a: UtxoInterface, b: UtxoInterface) =>
   a.value! - b.value!;
@@ -15,11 +15,10 @@ const defaultCompareFn: CompareUtxoFn = (a: UtxoInterface, b: UtxoInterface) =>
 export function greedyCoinSelector(
   compare: CompareUtxoFn = defaultCompareFn
 ): CoinSelector {
-  return (
-    u: UtxoInterface[],
-    o: RecipientInterface[],
-    getter: ChangeAddressFromAssetGetter
-  ) => greedyCoinSelection(u, o, getter, compare);
+  const errorHandler = (asset: string) => {
+    throw new Error(`coin selector error: ${asset}`);
+  };
+  return greedyCoinSelection(compare)(errorHandler);
 }
 
 /**
@@ -27,95 +26,21 @@ export function greedyCoinSelector(
  * @param unspents a set of unspents.
  * @param outputs the outputs targetted by the coin selection
  */
-function greedyCoinSelection(
+const greedyCoinSelection = (sortFn: CompareUtxoFn) => (
+  errorHandler: HandleCoinSelectorErrorFn
+) => (
   unspents: UtxoInterface[],
-  outputs: RecipientInterface[],
-  changeAddressGetter: ChangeAddressFromAssetGetter,
-  sortFn: CompareUtxoFn
-): CoinSelectionResult {
-  unspents = unspents.filter(utxo => !isBlindedUtxo(utxo));
+  recipients: RecipientInterface[],
+  changeAddressGetter: ChangeAddressFromAssetGetter
+): CoinSelectionResult => {
+  const coinSelectFn = coinSelect(sortFn)(errorHandler)(unspents);
+  const makeChangesFn = makeChanges(changeAddressGetter);
 
-  const result: CoinSelectionResult = {
-    selectedUtxos: [],
-    changeOutputs: [],
+  const recipientsMap = reduceRecipients(recipients);
+  const selectedUtxos = coinSelectFn(recipientsMap);
+
+  return {
+    selectedUtxos,
+    changeOutputs: makeChangesFn(recipientsMap)(selectedUtxos),
   };
-
-  const utxosGroupedByAsset = groupBy(unspents, 'asset') as Record<
-    string,
-    UtxoInterface[]
-  >;
-  const outputsGroupedByAsset = groupBy(outputs, 'asset') as Record<
-    string,
-    RecipientInterface[]
-  >;
-
-  for (const [asset, outputs] of Object.entries(outputsGroupedByAsset)) {
-    const unspents = utxosGroupedByAsset[asset];
-    if (!unspents) {
-      throw new Error('need unspents for the asset: ' + asset);
-    }
-
-    const targetAmount: number = outputs.reduce(
-      (acc: number, output: RecipientInterface) => acc + output.value,
-      0
-    );
-
-    const { selected, changeAmount } = selectUtxos(
-      unspents,
-      targetAmount,
-      sortFn
-    );
-
-    result.selectedUtxos.push(...selected);
-
-    if (changeAmount > 0) {
-      const changeAddr = changeAddressGetter(asset);
-      if (!changeAddr) {
-        throw new Error('need change address for asset: ' + asset);
-      }
-
-      result.changeOutputs.push({
-        asset: asset,
-        value: changeAmount,
-        address: changeAddr,
-      });
-    }
-  }
-
-  return result;
-}
-
-function selectUtxos(
-  utxos: UtxoInterface[],
-  targetAmount: number,
-  compareFn: CompareUtxoFn
-): {
-  selected: UtxoInterface[];
-  changeAmount: number;
-} {
-  utxos = utxos.sort(compareFn);
-  const selected: UtxoInterface[] = [];
-  let total = 0;
-  for (const utxo of utxos) {
-    if (!isBlindedUtxo(utxo)) {
-      selected.push(utxo);
-      total += utxo.value!;
-    }
-
-    if (total >= targetAmount) {
-      return {
-        selected,
-        changeAmount: total - targetAmount,
-      };
-    }
-  }
-
-  throw new Error('not enough utxos in wallet to fund: ' + targetAmount);
-}
-
-function groupBy(xs: Array<any>, key: string) {
-  return xs.reduce(function(rv, x) {
-    (rv[x[key]] = rv[x[key]] || []).push(x);
-    return rv;
-  }, {});
-}
+};

--- a/src/coinselection/greedy.ts
+++ b/src/coinselection/greedy.ts
@@ -6,7 +6,12 @@ import {
   HandleCoinSelectorErrorFn,
 } from './../types';
 import { CoinSelectionResult, CoinSelector } from './coinSelector';
-import { coinSelect, makeChanges, reduceRecipients } from './utils';
+import {
+  checkCoinSelect,
+  coinSelect,
+  makeChanges,
+  reduceRecipients,
+} from './utils';
 
 const defaultCompareFn: CompareUtxoFn = (a: UtxoInterface, b: UtxoInterface) =>
   a.value! - b.value!;
@@ -38,9 +43,13 @@ const greedyCoinSelection = (sortFn: CompareUtxoFn) => (
 
   const recipientsMap = reduceRecipients(recipients);
   const selectedUtxos = coinSelectFn(recipientsMap);
+  const changeOutputs = makeChangesFn(recipientsMap)(selectedUtxos);
+
+  // check that input amount = output amount and input assets = output assets
+  checkCoinSelect([...recipients, ...changeOutputs])(selectedUtxos);
 
   return {
     selectedUtxos,
-    changeOutputs: makeChangesFn(recipientsMap)(selectedUtxos),
+    changeOutputs,
   };
 };

--- a/src/coinselection/utils.ts
+++ b/src/coinselection/utils.ts
@@ -1,0 +1,23 @@
+import { UtxoInterface } from '../types';
+
+const select = (asset: string) => (amount: number) => (
+  utxos: UtxoInterface[]
+): UtxoInterface[] => {
+  let amountToSelect = amount;
+  return utxos.filter(assetFilter(asset)).reduce((selected, utxo, index) => {
+    if (sumUtxos(selected) >= amount) return selected;
+    else selected.concat([utxo]);
+  }, []);
+};
+
+const sumUtxos = (utxos: UtxoInterface[]): number =>
+  utxos.reduce(
+    (sum: number, utxo: UtxoInterface) => (utxo.value ? sum + utxo.value : sum),
+    0
+  );
+
+const assetFilter = (assetToFilter: string) => ({
+  asset,
+}: {
+  asset?: string;
+}) => asset && asset === assetToFilter;

--- a/src/coinselection/utils.ts
+++ b/src/coinselection/utils.ts
@@ -42,7 +42,7 @@ const diff = (utxos: UtxoInterface[]) => (asset: string) => {
   return (amount: number) => sum - amount;
 };
 
-export const sumUtxos = (asset: string) => (utxos: UtxoInterface[]): number =>
+const sumUtxos = (asset: string) => (utxos: UtxoInterface[]): number =>
   utxos
     .filter(assetFilter(asset))
     .reduce(

--- a/src/coinselection/utils.ts
+++ b/src/coinselection/utils.ts
@@ -1,20 +1,89 @@
-import { UtxoInterface } from '../types';
+import {
+  ChangeAddressFromAssetGetter,
+  CompareUtxoFn,
+  HandleCoinSelectorErrorFn,
+  RecipientInterface,
+  UtxoInterface,
+} from '../types';
 
-const select = (asset: string) => (amount: number) => (
-  utxos: UtxoInterface[]
-): UtxoInterface[] => {
-  let amountToSelect = amount;
-  return utxos.filter(assetFilter(asset)).reduce((selected, utxo, index) => {
-    if (sumUtxos(selected) >= amount) return selected;
-    else selected.concat([utxo]);
-  }, []);
+export const makeChanges = (
+  changeAddressGetter: ChangeAddressFromAssetGetter
+) => (toSelect: Map<string, number>) => (
+  selectedUtxos: UtxoInterface[]
+): RecipientInterface[] => {
+  const recipients: RecipientInterface[] = [];
+  toSelect.forEach((amount: number, asset: string) => {
+    const changeAmount = diff(selectedUtxos)(asset)(amount);
+    if (changeAmount > 0) {
+      // has change
+      recipients.push({
+        address: changeAddressGetter(asset),
+        asset,
+        value: amount,
+      });
+    }
+  });
+  return recipients;
 };
 
-const sumUtxos = (utxos: UtxoInterface[]): number =>
-  utxos.reduce(
-    (sum: number, utxo: UtxoInterface) => (utxo.value ? sum + utxo.value : sum),
-    0
-  );
+const diff = (utxos: UtxoInterface[]) => (asset: string) => {
+  const sum = sumUtxos(asset)(utxos);
+  return (amount: number) => sum - amount;
+};
+
+const sumUtxos = (asset: string) => (utxos: UtxoInterface[]): number =>
+  utxos
+    .filter(assetFilter(asset))
+    .reduce(
+      (sum: number, utxo: UtxoInterface) =>
+        utxo.value ? sum + utxo.value : sum,
+      0
+    );
+
+export const coinSelect = (compareFn: CompareUtxoFn) => (
+  errorHandler: HandleCoinSelectorErrorFn
+) => (utxos: UtxoInterface[]) => (toSelect: Map<string, number>) => {
+  const selectors: ((utxos: UtxoInterface[]) => UtxoInterface[])[] = [];
+  const coinSelectorFilter = coinSelectUtxosFilter(compareFn)(errorHandler);
+  toSelect.forEach((amount: number, asset: string) => {
+    selectors.push(coinSelectorFilter(asset)(amount));
+  });
+  return selectors.flatMap(fnSelect => fnSelect(utxos));
+};
+
+export function reduceRecipients(recipients: RecipientInterface[]) {
+  return recipients.reduce(recipientsReducer, new Map<string, number>());
+}
+
+function recipientsReducer(
+  results: Map<string, number>,
+  next: RecipientInterface
+) {
+  results.set(next.asset, (results.get(next.asset) || 0) + next.value);
+  return results;
+}
+
+const coinSelectUtxosFilter = (compareFn: CompareUtxoFn) => (
+  errorHandler: HandleCoinSelectorErrorFn
+) => (asset: string) => (amount: number) => (
+  utxos: UtxoInterface[]
+): UtxoInterface[] => {
+  let amtSelected = 0;
+  const selected = utxos
+    .filter(assetFilter(asset))
+    .sort(compareFn)
+    .reduce((selected: UtxoInterface[], next: UtxoInterface) => {
+      if (amtSelected <= amount && next.value) {
+        selected.push(next);
+        amtSelected += next.value;
+      }
+      return selected;
+    }, []);
+
+  // if not enougth amount is selected, use errorHandler
+  if (amtSelected < amount) errorHandler(asset, amount, amtSelected);
+  return selected;
+};
 
 const assetFilter = (assetToFilter: string) => ({
   asset,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,7 @@ export interface AddressInterface {
 }
 
 // define a type using to implement change's address strategy
-export type ChangeAddressFromAssetGetter = (
-  asset: string
-) => string | undefined;
+export type ChangeAddressFromAssetGetter = (asset: string) => string;
 
 // define function that takes a script as input and returns a blinding key (or undefined)
 export type BlindingKeyGetter = (script: string) => string | undefined;
@@ -83,3 +81,10 @@ export interface TxInterface {
   vin: Array<InputInterface>;
   vout: Array<BlindedOutputInterface | UnblindedOutputInterface>;
 }
+
+export type CompareUtxoFn = (a: UtxoInterface, b: UtxoInterface) => number;
+export type HandleCoinSelectorErrorFn = (
+  asset: string,
+  need: number,
+  has: number
+) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export interface TxInterface {
 }
 
 export type CompareUtxoFn = (a: UtxoInterface, b: UtxoInterface) => number;
-export type HandleCoinSelectorErrorFn = (
+export type CoinSelectorErrorFn = (
   asset: string,
   need: number,
   has: number

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -8,7 +8,12 @@ import {
   ChangeAddressFromAssetGetter,
 } from './types';
 import { getNetwork, toOutpoint } from './utils';
-import { buildTx as buildTxFunction, BuildTxArgs } from './transaction';
+import {
+  craftMultipleRecipientsPset,
+  BuildTxArgs,
+  DEFAULT_SATS_PER_BYTE,
+  craftSingleRecipientPset,
+} from './transaction';
 import { fetchAndUnblindUtxos } from './explorer/utxos';
 
 /**
@@ -24,6 +29,13 @@ export interface WalletInterface {
     coinSelector: CoinSelector,
     changeAddressByAsset: ChangeAddressFromAssetGetter,
     addFee?: boolean,
+    satsPerByte?: number
+  ): string;
+  sendTx(
+    recipient: RecipientInterface,
+    coinSelector: CoinSelector,
+    changeAddress: string,
+    substractFee?: boolean,
     satsPerByte?: number
   ): string;
 }
@@ -71,7 +83,24 @@ export class Wallet implements WalletInterface {
       unspents: this.cache.getAll(),
     };
 
-    return buildTxFunction(args);
+    return craftMultipleRecipientsPset(args);
+  }
+
+  sendTx(
+    recipient: RecipientInterface,
+    coinSelector: CoinSelector,
+    changeAddress: string,
+    substractFee = false,
+    satsPerByte = DEFAULT_SATS_PER_BYTE
+  ) {
+    return craftSingleRecipientPset(
+      this.cache.getAll(),
+      recipient,
+      coinSelector,
+      changeAddress,
+      substractFee,
+      satsPerByte
+    );
   }
 }
 

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../src';
 
 import { APIURL, faucet } from './_regtest';
-import { sender } from './fixtures/wallet.keys';
+import { newRandomMnemonic } from './fixtures/wallet.keys';
 
 jest.setTimeout(80000);
 
@@ -21,6 +21,7 @@ describe('esplora', () => {
   let unconfidentialSenderAddress: string;
 
   beforeAll(async () => {
+    const sender = newRandomMnemonic();
     senderAddress = await sender.getNextAddress();
     unconfidentialSenderAddress = address.fromConfidential(
       senderAddress.confidentialAddress

--- a/test/fixtures/wallet.keys.ts
+++ b/test/fixtures/wallet.keys.ts
@@ -1,7 +1,5 @@
 import { networks, payments, ECPair } from 'liquidjs-lib';
-
-import { PrivateKey } from '../../src/identity/privatekey';
-import { IdentityType } from '../../src/types';
+import { Mnemonic } from '../../src/identity/mnemonic';
 
 const network = networks.regtest;
 // generate a random keyPair for bob
@@ -15,14 +13,7 @@ const blindKeyPair2 = ECPair.fromWIF(
   network
 );
 
-export const sender = new PrivateKey({
-  chain: 'regtest',
-  type: IdentityType.PrivateKey,
-  opts: {
-    signingKeyWIF: 'cPNMJD4VyFnQjGbGs3kcydRzAbDCXrLAbvH6wTCqs88qg1SkZT3J',
-    blindingKeyWIF: 'cRdrvnPMLV7CsEak2pGrgG4MY7S3XN1vjtcgfemCrF7KJRPeGgW6',
-  },
-});
+export const newRandomMnemonic = () => Mnemonic.Random('regtest');
 
 // this is random address for who is receiving the withdrawal
 export const recipientAddress = payments.p2wpkh({

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -57,7 +57,7 @@ describe('buildTx', () => {
 
   it('should build a confidential transaction spending USDT', async () => {
     // create a tx using wallet
-    const tx = (await senderWallet).createTx();
+    const tx = senderWallet.createTx();
 
     const recipients: RecipientInterface[] = [
       {
@@ -77,7 +77,7 @@ describe('buildTx', () => {
 
   it('should build a confidential transaction spending LBTC', async () => {
     // create a tx using wallet
-    const tx = (await senderWallet).createTx();
+    const tx = senderWallet.createTx();
 
     const recipients: RecipientInterface[] = [
       {
@@ -91,8 +91,8 @@ describe('buildTx', () => {
     assert.doesNotThrow(() => Psbt.fromBase64(unsignedTx));
   });
 
-  it('should be able to create a complex transaction and broadcast it', async () => {
-    const tx = (await senderWallet).createTx();
+  it.only('should be able to create a complex transaction and broadcast it', async () => {
+    const tx = senderWallet.createTx();
 
     const recipients = [
       {
@@ -120,12 +120,19 @@ describe('buildTx', () => {
     const transaction = Transaction.fromHex(psetToUnsignedHex(unsignedTx));
     for (let i = 0; i < transaction.ins.length; i++) {
       const input = transaction.ins[i];
-      const blindingData = args.unspents.find(
+      const utxo = args.unspents.find(
         u =>
           input.hash.equals(Buffer.from(u.txid, 'hex').reverse()) &&
           u.vout === input.index
-      )!.unblindData;
-      blindingDataMap.set(i, blindingData);
+      );
+
+      if (!utxo) throw new Error('cannot find utxo');
+
+      const blindingData = utxo.unblindData;
+
+      if (blindingData) {
+        blindingDataMap.set(i, blindingData);
+      }
     }
 
     // blind only the change output

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -11,7 +11,7 @@ import { BuildTxArgs, craftMultipleRecipientsPset } from '../src/transaction';
 import { RecipientInterface } from '../src/types';
 
 import { APIURL, broadcastTx, faucet, mint } from './_regtest';
-import { recipientAddress, sender } from './fixtures/wallet.keys';
+import { recipientAddress, newRandomMnemonic } from './fixtures/wallet.keys';
 
 jest.setTimeout(50000);
 
@@ -22,6 +22,7 @@ describe('buildTx', () => {
   let args: BuildTxArgs;
   let senderAddress = '';
   let senderBlindingKey = '';
+  const sender = newRandomMnemonic();
 
   beforeAll(async () => {
     const addrI = await sender.getNextAddress();
@@ -176,6 +177,7 @@ describe('sendTx', () => {
     recipient: RecipientInterface,
     substractScenario: boolean
   ) => {
+    const sender = newRandomMnemonic();
     const addrI = await sender.getNextAddress();
     const changeAddress = (await sender.getNextChangeAddress())
       .confidentialAddress;
@@ -215,16 +217,14 @@ describe('sendTx', () => {
   });
 
   it('should throw an error if not enough fund', async () => {
-    await makeTest(
-      makeRecipient(networks.regtest.assetHash)(1_0000_0000 + 1),
-      false
+    assert.rejects(
+      makeTest(makeRecipient(networks.regtest.assetHash)(1_0000_0000), false)
     );
   });
 
   it('should throw an error if not enough fund to pay fees (no substract fee from recipient)', async () => {
-    await makeTest(
-      makeRecipient(networks.regtest.assetHash)(1_0000_0000),
-      false
+    assert.rejects(
+      makeTest(makeRecipient(networks.regtest.assetHash)(1_0000_0000), false)
     );
   });
 

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -91,7 +91,7 @@ describe('buildTx', () => {
     assert.doesNotThrow(() => Psbt.fromBase64(unsignedTx));
   });
 
-  it.only('should be able to create a complex transaction and broadcast it', async () => {
+  it('should be able to create a complex transaction and broadcast it', async () => {
     const tx = senderWallet.createTx();
 
     const recipients = [

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../src/types';
 
 import { APIURL, faucet } from './_regtest';
-import { recipientAddress, sender } from './fixtures/wallet.keys';
+import { recipientAddress, newRandomMnemonic } from './fixtures/wallet.keys';
 
 jest.setTimeout(500000);
 
@@ -21,6 +21,7 @@ describe('Wallet - Transaction builder', () => {
   let senderAddress: AddressInterface;
 
   beforeAll(async () => {
+    const sender = newRandomMnemonic();
     senderAddress = await sender.getNextAddress();
     faucetTxID = await faucet(senderAddress.confidentialAddress);
   });


### PR DESCRIPTION
**This PR changes the `CoinSelector` type: adding a way to handle errors via `CoinSelectorErrorFn`.**

### Coin selection

- move (and simplify) the coin selection logic from `greedy.ts` to `coinselection/utils.ts` file. 
- `CoinSelectorErrorFn` defines a function launched in case of "not enough fund error" in coin selection. 
- update `wallet.buildTx` according to new error handling function.

It lets to specify the behavior of the coin selector if the utxos can't fund the array of recipients. Instead of throw an error, we can handle the error according to specific needs (like[ subtract fee amount scenario](https://github.com/vulpemventures/marina/issues/93) - see `sendTx`). 

### wallet.sendTx

- add `sendTx` method to `WalletInterface`: this function can be used to create a **withdraw transaction** (= a single recipient tx): a really common case in our apps.
- `sendTx` takes a boolean `substractFee`. If enabled, it will use a custom `CoinSelectorErrorFn` in case of the recipient's asset is the fee asset (L-BTC). This error handler will update the recipient's value: set to (max value of utxos - fee value). 
- test `sendTx` in `transaction.test.ts`.

@tiero please review
