### PR TITLE
export `restorerFromState` function

### DIFF
--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -156,7 +156,7 @@ export interface StateRestorerOpts {
   lastUsedInternalIndex?: number;
 }
 
-function restorerFromState<R extends IdentityInterface>(
+export function restorerFromState<R extends IdentityInterface>(
   identity: R
 ): Restorer<StateRestorerOpts, R> {
   return async ({ lastUsedExternalIndex, lastUsedInternalIndex }) => {


### PR DESCRIPTION
restorerFromState works with all IdentityInterface so useful to export it in order to rewrite custom restorers in apps.
@tiero please review this