### PR TITLE
use fetch() instead of axios()

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "bip32": "^2.0.6",
     "bip39": "^3.0.3",
     "bs58check": "^2.1.2",
+    "isomorphic-fetch": "^3.0.0",
     "liquidjs-lib": "^5.2.2",
     "marina-provider": "^1.0.0",
     "slip77": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "bip32": "^2.0.6",
     "bip39": "^3.0.3",
     "bs58check": "^2.1.2",
-    "isomorphic-fetch": "^3.0.0",
+    "cross-fetch": "^3.1.4",
     "liquidjs-lib": "^5.2.2",
     "marina-provider": "^1.0.0",
     "slip77": "^0.1.1",

--- a/src/explorer/esplora.ts
+++ b/src/explorer/esplora.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { getWithFetch } from '../network';
 import { Transaction, TxOutput } from 'liquidjs-lib';
 import {
   TxInterface,
@@ -17,7 +17,7 @@ import { EsploraTx, EsploraUtxo } from './types';
  * @param url esplora URL
  */
 export async function fetchTxHex(txId: string, url: string): Promise<string> {
-  return (await axios.get(`${url}/tx/${txId}/hex`)).data;
+  return await getWithFetch(`${url}/tx/${txId}/hex`);
 }
 
 /**
@@ -26,10 +26,7 @@ export async function fetchTxHex(txId: string, url: string): Promise<string> {
  * @param url the esplora URL
  */
 export async function fetchTx(txId: string, url: string): Promise<TxInterface> {
-  return esploraTxToTxInterface(
-    (await axios.get(`${url}/tx/${txId}`)).data,
-    url
-  );
+  return esploraTxToTxInterface(await getWithFetch(`${url}/tx/${txId}`), url);
 }
 
 /**
@@ -41,9 +38,9 @@ export async function fetchUtxos(
   address: string,
   url: string
 ): Promise<Output[]> {
-  const esploraUtxos: EsploraUtxo[] = (
-    await axios.get(`${url}/address/${address}/utxo`)
-  ).data;
+  const esploraUtxos: EsploraUtxo[] = await getWithFetch(
+    `${url}/address/${address}/utxo`
+  );
   return Promise.all(esploraUtxos.map(outpointToUtxo(url)));
 }
 

--- a/src/explorer/transaction.ts
+++ b/src/explorer/transaction.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { getWithFetch } from '../network';
 import UnblindError from '../error/unblind-error';
 import { BlindingKeyGetter, isUnblindedOutput, TxInterface } from '../types';
 import { unblindOutput } from '../utils';
@@ -213,6 +213,5 @@ async function fetch25newestTxsForAddress(
     url += `/${lastSeenTxid}`;
   }
 
-  const response = await axios.get(url);
-  return response.data;
+  return await getWithFetch(url);
 }

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,7 +1,7 @@
-require('isomorphic-fetch');
+import fetch from 'cross-fetch';
 
 /**
- * what to do if fetch() generated an error
+ * throw stringified fetch() error
  * @param response returned from the fetch() call
  */
 const dealWithFetchError = (response: Response) => {
@@ -11,24 +11,21 @@ const dealWithFetchError = (response: Response) => {
 /**
  * check the response type and return it
  * @param response returned from the fetch() call
+ * @returns promise of data
  */
-const getDataFromResponse = async (response: Response) => {
-  const isJson = response.headers
-    .get('content-type')
-    ?.includes('application/json');
+const getDataFromResponse = async (response: Response): Promise<any> => {
+  const contentTypes = response.headers.get('content-type');
+  const isJson = contentTypes?.includes('application/json');
   return isJson ? await response.json() : await response.text();
 };
 
 /**
  * get data from a given url using fetch()
  * @param url url for the webservice
+ * @returns promise of data
  */
-export const getWithFetch = async (url: string) => {
-  const response = await fetch(url, {
-    method: 'GET',
-    mode: 'cors',
-  });
+export const getWithFetch = async (url: string): Promise<any> => {
+  const response = await fetch(url, { method: 'get', mode: 'cors' });
   if (response.status !== 200) dealWithFetchError(response);
-  const data = await getDataFromResponse(response);
-  return data;
+  return await getDataFromResponse(response);
 };

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,10 +1,22 @@
+require('isomorphic-fetch');
+
 /**
  * what to do if fetch() generated an error
  * @param response returned from the fetch() call
  */
 const dealWithFetchError = (response: Response) => {
-  console.error(response);
   throw new Error(JSON.stringify(response));
+};
+
+/**
+ * check the response type and return it
+ * @param response returned from the fetch() call
+ */
+const getDataFromResponse = async (response: Response) => {
+  const isJson = response.headers
+    .get('content-type')
+    ?.includes('application/json');
+  return isJson ? await response.json() : await response.text();
 };
 
 /**
@@ -17,6 +29,6 @@ export const getWithFetch = async (url: string) => {
     mode: 'cors',
   });
   if (response.status !== 200) dealWithFetchError(response);
-  const data = await response.json();
+  const data = await getDataFromResponse(response);
   return data;
 };

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,0 +1,22 @@
+/**
+ * what to do if fetch() generated an error
+ * @param response returned from the fetch() call
+ */
+const dealWithFetchError = (response: Response) => {
+  console.error(response);
+  throw new Error(JSON.stringify(response));
+};
+
+/**
+ * get data from a given url using fetch()
+ * @param url url for the webservice
+ */
+export const getWithFetch = async (url: string) => {
+  const response = await fetch(url, {
+    method: 'GET',
+    mode: 'cors',
+  });
+  if (response.status !== 200) dealWithFetchError(response);
+  const data = await response.json();
+  return data;
+};

--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { getWithFetch } from '../network';
 import { IdentityInterface } from '../identity/identity';
 import { Multisig } from '../identity/multisig';
 import { MultisigWatchOnly } from '../identity/multisigWatchOnly';
@@ -87,7 +87,7 @@ async function addressHasBeenUsed(
   address: string,
   esploraURL: string
 ): Promise<boolean> {
-  const data = (await axios.get(`${esploraURL}/address/${address}/txs`)).data;
+  const data = await getWithFetch(`${esploraURL}/address/${address}/txs`);
   return data.length > 0;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4733,6 +4733,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -5868,6 +5876,13 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -8092,6 +8107,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-jest@^25.3.1:
   version "25.5.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.5.1.tgz#2913afd08f28385d54f2f4e828be4d261f4337c7"
@@ -8503,6 +8523,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -8567,10 +8592,23 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,6 +2814,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.3, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4733,14 +4740,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
-  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
-  dependencies:
-    node-fetch "^2.6.1"
-    whatwg-fetch "^3.4.1"
-
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -5877,12 +5876,10 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-fetch@^2.6.1:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -8107,11 +8104,6 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
-
 ts-jest@^25.3.1:
   version "25.5.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.5.1.tgz#2913afd08f28385d54f2f4e828be4d261f4337c7"
@@ -8523,11 +8515,6 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
-
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -8592,23 +8579,10 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@^3.4.1:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
-
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
Why we need to stop using axios and start using fetch:

- Google is enforcing Chrome extensions to adopt Manifest v3.
- With Manifest v3 it is mandatory to use service workers instead of the background script.
- Workers no longer provide XMLHttpRequest, but instead support the more modern fetch().
- Since axios uses XMLHttpRequest, it will not work under a service worker.
- So this module it will not work if included in a new Chrome extension.

@tiero please review