### PR TITLE
bump liquidjs 6.0.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12.x', '14.x', '16.x']
+        node: ['14.x', '16.x']
 
     steps:
       - name: Checkout repo

--- a/package.json
+++ b/package.json
@@ -72,18 +72,21 @@
     "@size-limit/preset-small-lib": "^4.9.1",
     "@types/bs58check": "^2.1.0",
     "@types/node": "^14.14.31",
+    "@types/tiny-secp256k1": "^2.0.1",
     "husky": "^4.3.7",
     "size-limit": "^4.9.1",
     "tsdx": "^0.14.1"
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "bip32": "^2.0.6",
+    "bip32": "^3.0.1",
     "bip39": "^3.0.3",
     "bs58check": "^2.1.2",
-    "liquidjs-lib": "^5.2.2",
+    "ecpair": "^2.0.1",
+    "liquidjs-lib": "^6.0.1",
     "marina-provider": "^1.0.0",
     "slip77": "^0.1.1",
+    "tiny-secp256k1": "^2.2.1",
     "tslib": "^2.3.1"
   }
 }

--- a/src/bip32.ts
+++ b/src/bip32.ts
@@ -1,0 +1,5 @@
+// bip32.ts use the factory from bip32 pkg + ecc to create a bip32 instance.
+
+import BIP32Factory from 'bip32';
+
+export const bip32 = BIP32Factory(require('tiny-secp256k1'));

--- a/src/identity/browserinject.ts
+++ b/src/identity/browserinject.ts
@@ -1,5 +1,4 @@
-import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
-// @ts-ignore
+import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import { MarinaProvider } from 'marina-provider';
 
 import { AddressInterface, IdentityType } from '../types';

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -1,11 +1,6 @@
-import {
-  Network,
-  Transaction,
-  networks,
-  confidential,
-  TxOutput,
-} from 'liquidjs-lib';
-import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+import { Transaction, networks, confidential, TxOutput } from 'liquidjs-lib';
+import { Network } from 'liquidjs-lib/src/networks';
+import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 
 import { AddressInterface, NetworkString } from '../types';
 import { IdentityType } from '../types';

--- a/src/identity/masterpubkey.ts
+++ b/src/identity/masterpubkey.ts
@@ -1,7 +1,8 @@
-import { BIP32Interface, fromBase58 } from 'bip32';
+import { BIP32Interface } from 'bip32';
 import { payments } from 'liquidjs-lib';
-import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import { Slip77Interface, fromMasterBlindingKey } from 'slip77';
+import { bip32 } from '../bip32';
 
 import { AddressInterface, IdentityType } from '../types';
 import {
@@ -53,7 +54,7 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
       throw new Error('Master blinding key is not valid');
     }
 
-    this.masterPublicKeyNode = fromBase58(xpub);
+    this.masterPublicKeyNode = bip32.fromBase58(xpub);
     this.masterBlindingKeyNode = fromMasterBlindingKey(
       args.opts.masterBlindingKey
     );

--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -1,8 +1,10 @@
-import { BIP32Interface, fromSeed as bip32fromSeed } from 'bip32';
+import { BIP32Interface } from 'bip32';
 import * as bip39 from 'bip39';
-import { ECPair, Psbt, bip32, networks, Network } from 'liquidjs-lib';
-import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+import { ECPair, Psbt, networks } from 'liquidjs-lib';
+import { Network } from 'liquidjs-lib/src/networks';
+import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import { Slip77Interface, fromSeed as slip77fromSeed } from 'slip77';
+import { bip32 } from '../bip32';
 
 import { IdentityType } from '../types';
 import { checkIdentityType, checkMnemonic, fromXpub } from '../utils';
@@ -44,7 +46,7 @@ export class Mnemonic extends MasterPublicKey implements IdentityInterface {
     const walletSeed = bip39.mnemonicToSeedSync(args.opts.mnemonic);
     // generate the master private key from the wallet seed
     const network = (networks as Record<string, Network>)[args.chain];
-    const masterPrivateKeyNode = bip32fromSeed(walletSeed, network);
+    const masterPrivateKeyNode = bip32.fromSeed(walletSeed, network);
 
     // compute and expose the masterPublicKey in this.masterPublicKey
     const baseNode = masterPrivateKeyNode.derivePath(

--- a/src/identity/multisig.ts
+++ b/src/identity/multisig.ts
@@ -1,6 +1,8 @@
-import { BIP32Interface, fromPublicKey, fromSeed } from 'bip32';
+import { BIP32Interface } from 'bip32';
 import { mnemonicToSeedSync } from 'bip39';
-import { address, ECPair, Network, networks, Psbt } from 'liquidjs-lib';
+import { address, ECPair, networks, Psbt } from 'liquidjs-lib';
+import { Network } from 'liquidjs-lib/src/networks';
+import { bip32 } from '../bip32';
 
 import { IdentityType, HDSignerMultisig } from '../types';
 import { checkIdentityType, checkMnemonic, toXpub } from '../utils';
@@ -27,7 +29,7 @@ export class Multisig extends MultisigWatchOnly implements IdentityInterface {
 
     const walletSeed = mnemonicToSeedSync(args.opts.signer.mnemonic);
     const network = (networks as Record<string, Network>)[args.chain];
-    const masterPrivateKeyNode = fromSeed(walletSeed, network);
+    const masterPrivateKeyNode = bip32.fromSeed(walletSeed, network);
 
     const baseNode = masterPrivateKeyNode.derivePath(
       args.opts.signer.baseDerivationPath || DEFAULT_BASE_DERIVATION_PATH
@@ -99,11 +101,13 @@ export class Multisig extends MultisigWatchOnly implements IdentityInterface {
 
   getXPub(): string {
     return toXpub(
-      fromPublicKey(
-        this.baseNode.publicKey,
-        this.baseNode.chainCode,
-        this.network
-      ).toBase58()
+      bip32
+        .fromPublicKey(
+          this.baseNode.publicKey,
+          this.baseNode.chainCode,
+          this.network
+        )
+        .toBase58()
     );
   }
 

--- a/src/identity/privatekey.ts
+++ b/src/identity/privatekey.ts
@@ -1,5 +1,6 @@
-import { ECPair, ECPairInterface, Psbt, payments } from 'liquidjs-lib';
-import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+import { ECPairInterface } from 'ecpair';
+import { ECPair, Psbt, payments } from 'liquidjs-lib';
+import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 
 import { AddressInterface, IdentityType } from '../types';
 import { checkIdentityType } from '../utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { networks, address, payments, ECPair } from 'liquidjs-lib';
+export { networks, address, payments, ECPair, AssetHash } from 'liquidjs-lib';
 
 export * from './identity/identity';
 export * from './identity/mnemonic';

--- a/src/p2ms.ts
+++ b/src/p2ms.ts
@@ -1,10 +1,5 @@
-import {
-  BIP32Interface,
-  networks,
-  payments,
-  crypto,
-  address,
-} from 'liquidjs-lib';
+import { BIP32Interface } from 'bip32';
+import { networks, payments, crypto, address } from 'liquidjs-lib';
 import { Slip77Interface, fromSeed } from 'slip77';
 
 import { MultisigPayment } from './types';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,15 @@
-import { fromBase58 } from 'bip32';
 import { setDefaultWordlist, validateMnemonic } from 'bip39';
 import b58 from 'bs58check';
 import {
-  Network,
   Psbt,
   Transaction,
   confidential,
   networks,
   address,
 } from 'liquidjs-lib';
+import { Network } from 'liquidjs-lib/src/networks';
 import { fromMasterBlindingKey } from 'slip77';
+import { bip32 } from './bip32';
 
 import {
   AddressInterface,
@@ -157,7 +157,7 @@ export function toXpub(anyPub: string) {
 
 export function isValidXpub(xpub: string, network?: Network): boolean {
   try {
-    fromBase58(xpub, network);
+    bip32.fromBase58(xpub, network);
   } catch (e) {
     return false;
   }
@@ -258,7 +258,7 @@ export function checkMnemonic(mnemonic: string, language?: string) {
 
 export function checkMasterPublicKey(masterPublicKey: string) {
   try {
-    fromBase58(masterPublicKey);
+    bip32.fromBase58(masterPublicKey);
   } catch {
     throw new Error(`invalid master public key: ${masterPublicKey}`);
   }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,4 +1,4 @@
-import { Network, Psbt } from 'liquidjs-lib';
+import { Psbt } from 'liquidjs-lib';
 import { CoinSelector } from './coinselection/coinSelector';
 import {
   AddressInterface,
@@ -15,6 +15,7 @@ import {
   craftSingleRecipientPset,
 } from './transaction';
 import { fetchAndUnblindUtxos } from './explorer/utxos';
+import { Network } from 'liquidjs-lib/src/networks';
 
 /**
  * Wallet abstraction.

--- a/test/mnemonic.identity.test.ts
+++ b/test/mnemonic.identity.test.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import { fromSeed as bip32fromSeed } from 'bip32';
 import { mnemonicToSeedSync } from 'bip39';
 import {
   Psbt,
@@ -9,8 +8,9 @@ import {
   payments,
   address,
   TxOutput,
+  AssetHash,
 } from 'liquidjs-lib';
-import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import { fromSeed as slip77fromSeed } from 'slip77';
 
 import {
@@ -24,9 +24,11 @@ import {
 } from '../src';
 
 import { Restorer } from '../src';
+import { bip32 } from '../src/bip32';
 import { faucet, fetchTxHex, fetchUtxos } from './_regtest';
 
 const network = networks.regtest;
+const lbtc = AssetHash.fromHex(network.assetHash, false);
 
 jest.setTimeout(500_000);
 
@@ -40,7 +42,7 @@ const validOpts: IdentityOpts<MnemonicOpts> = {
 };
 
 const seedFromValidMnemonic = mnemonicToSeedSync(validOpts.opts.mnemonic);
-const masterPrivateKeyFromValidMnemonic = bip32fromSeed(
+const masterPrivateKeyFromValidMnemonic = bip32.fromSeed(
   seedFromValidMnemonic,
   network
 );
@@ -150,13 +152,13 @@ describe('Identity: Mnemonic', () => {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(49999500),
             script,
-            asset: network.assetHash,
+            asset: lbtc.bytes,
           },
           {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(60000000),
             script: Buffer.alloc(0),
-            asset: network.assetHash,
+            asset: lbtc.bytes,
           },
         ]);
 
@@ -206,13 +208,13 @@ describe('Identity: Mnemonic', () => {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(49999500),
             script,
-            asset: network.assetHash,
+            asset: lbtc.bytes,
           },
           {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(60000000),
             script: Buffer.alloc(0),
-            asset: network.assetHash,
+            asset: lbtc.bytes,
           },
         ]);
 
@@ -257,13 +259,13 @@ describe('Identity: Mnemonic', () => {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(49999500),
             script,
-            asset: network.assetHash,
+            asset: lbtc.bytes,
           },
           {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(60000000),
             script: Buffer.alloc(0),
-            asset: network.assetHash,
+            asset: lbtc.bytes,
           },
         ]);
 

--- a/test/multisig.identity.test.ts
+++ b/test/multisig.identity.test.ts
@@ -7,8 +7,9 @@ import {
   Psbt,
   confidential,
   TxOutput,
+  AssetHash,
 } from 'liquidjs-lib';
-import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 
 import {
   IdentityOpts,
@@ -21,6 +22,9 @@ import {
 } from '../src';
 
 import { faucet, fetchTxHex, fetchUtxos, sleep } from './_regtest';
+
+const network = networks.regtest;
+const lbtc = AssetHash.fromHex(network.assetHash, false);
 
 jest.setTimeout(60000);
 
@@ -103,13 +107,13 @@ describe('Identity:  Multisig', () => {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(49999500),
             script,
-            asset: networks.regtest.assetHash,
+            asset: lbtc.bytes,
           },
           {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(60000000),
             script: Buffer.alloc(0),
-            asset: networks.regtest.assetHash,
+            asset: lbtc.bytes,
           },
         ]);
 
@@ -174,13 +178,13 @@ describe('Identity:  Multisig', () => {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(49999500),
             script,
-            asset: multisig.network.assetHash,
+            asset: lbtc.bytes,
           },
           {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(60000000),
             script: Buffer.alloc(0),
-            asset: multisig.network.assetHash,
+            asset: lbtc.bytes,
           },
         ]);
 

--- a/test/privatekey.identity.test.ts
+++ b/test/privatekey.identity.test.ts
@@ -7,6 +7,7 @@ import {
   networks,
   payments,
   address,
+  AssetHash,
 } from 'liquidjs-lib';
 
 import {
@@ -20,6 +21,8 @@ import {
 import { faucet, fetchTxHex, fetchUtxos } from './_regtest';
 
 const network = networks.regtest;
+const lbtc = AssetHash.fromHex(network.assetHash, false);
+
 // increase default timeout of jest
 jest.setTimeout(15000);
 const validOpts: IdentityOpts<PrivateKeyOpts> = {
@@ -87,13 +90,13 @@ describe('Identity: Private key', () => {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(49999500),
             script: p2wpkh.output!,
-            asset: network.assetHash,
+            asset: lbtc.bytes,
           },
           {
             nonce: Buffer.from('00', 'hex'),
             value: confidential.satoshiToConfidentialValue(60000000),
             script: Buffer.alloc(0),
-            asset: network.assetHash,
+            asset: lbtc.bytes,
           },
         ]);
       const privateKey = new PrivateKey(validOpts);

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { address, networks, Psbt, Transaction } from 'liquidjs-lib';
-import { BlindingDataLike } from 'liquidjs-lib/types/psbt';
+import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 
 import { walletFromAddresses, WalletInterface } from '../src';
 import { greedyCoinSelector } from '../src/coinselection/greedy';

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { bip32 } from 'liquidjs-lib';
+import { bip32 } from '../src/bip32';
 
 import { fromXpub, toXpub } from '../src/utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,6 +1368,13 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
+"@types/randombytes@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/randombytes/-/randombytes-2.0.0.tgz#0087ff5e60ae68023b9bc4398b406fea7ad18304"
+  integrity sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
@@ -1379,6 +1386,20 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/tiny-secp256k1@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/tiny-secp256k1/-/tiny-secp256k1-2.0.1.tgz#a2a1a1e8f377ac63419464c6ce05b8bec109c39c"
+  integrity sha512-3UmSOVZR8nqCk50r/ODnT58+FutNzf1NpJHSW69Lc33ZDvOVciKHYOcBN/BXPzYWzWvM0GvHVnxv6HNHxOKXbg==
+  dependencies:
+    tiny-secp256k1 "*"
+
+"@types/wif@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/wif/-/wif-2.0.2.tgz#5bd845e29406bc7d49acca6d2a6c3230f3b53d3c"
+  integrity sha512-IiIuBeJzlh4LWJ7kVTrX0nwB60OG0vvGTaWC/SgSbVFw7uYUTF6gEuvDZ1goWkeirekJDD58Y8g7NljQh2fNkA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -2074,10 +2095,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
-  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+bech32@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -2106,7 +2127,7 @@ bip174-liquid@^1.0.3:
   resolved "https://registry.yarnpkg.com/bip174-liquid/-/bip174-liquid-1.0.3.tgz#5009444091da80277c45ee90c255d7919646f907"
   integrity sha512-e69sC0Cq2tBJuhG2+wieXv40DN13YBR/wbIjZp4Mqwpar5vQm8Ldqijdd6N33XG7LtfvQi/zKm5fSzdPY/9mgw==
 
-bip32@^2.0.4, bip32@^2.0.6:
+bip32@^2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.6.tgz#6a81d9f98c4cd57d05150c60d8f9e75121635134"
   integrity sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==
@@ -2116,6 +2137,18 @@ bip32@^2.0.4, bip32@^2.0.6:
     create-hash "^1.2.0"
     create-hmac "^1.1.7"
     tiny-secp256k1 "^1.1.3"
+    typeforce "^1.11.5"
+    wif "^2.0.6"
+
+bip32@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-3.0.1.tgz#1d1121469cce6e910e0ec3a5a1990dd62687e2a3"
+  integrity sha512-Uhpp9aEx3iyiO7CpbNGFxv9WcMIVdGoHG04doQ5Ln0u60uwDah7jUSc3QMV/fSZGm/Oo01/OeAmYevXV+Gz5jQ==
+  dependencies:
+    "@types/node" "10.12.18"
+    bs58check "^2.1.1"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
     typeforce "^1.11.5"
     wif "^2.0.6"
 
@@ -2136,7 +2169,7 @@ bip66@^1.1.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0:
+bitcoin-ops@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
   integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
@@ -2150,10 +2183,10 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blech32@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/blech32/-/blech32-1.0.1.tgz#400b9a8953ff80164553a8cf58fece208762e16b"
-  integrity sha512-1/vr1wwB8jvfVCkLQMVXLaIyx7Lgxh/6IqVuQlSsCNzWNzU+64oXzOQ/9BRnN4GANjx9i0O3OSQonDlL4FraSA==
+blech32@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/blech32/-/blech32-1.1.0.tgz#3f7ad05e18f36db2162cb5e8acf603fdd8a3d793"
+  integrity sha512-TGl9OgRq7woBzhQX1S5Im7opgyb2lpnEgqoApHpEZ8hgo8NSQkwJrf1Qxbg6frobTdBWxo2c+sFLjZFWGMLZHA==
   dependencies:
     long "^4.0.0"
 
@@ -2802,7 +2835,7 @@ create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
     ripemd160 "^2.0.1"
     sha.js "^2.4.0"
 
-create-hmac@^1.1.0, create-hmac@^1.1.3, create-hmac@^1.1.4, create-hmac@^1.1.7:
+create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
   integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
@@ -3202,6 +3235,15 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecpair@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ecpair/-/ecpair-2.0.1.tgz#e25ab416f1ecb6b05477ca601313df937b075d2e"
+  integrity sha512-iT3wztQMeE/nDTlfnAg8dAFUfBS7Tq2BXzq3ae6L+pWgFU0fQ3l0woTzdTBrJV3OxBjxbzjq8EQhAbEmJNWFSw==
+  dependencies:
+    randombytes "^2.1.0"
+    typeforce "^1.18.0"
+    wif "^2.0.6"
 
 electron-to-chromium@^1.3.867:
   version "1.3.872"
@@ -5390,28 +5432,26 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-liquidjs-lib@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-5.2.2.tgz#72a6fa4a32b74c49b7f9e9f9e58e31e55ff6a264"
-  integrity sha512-wHwJGGQi0zU3DrOaFPqfa36i3W0XojA/aoXbr66ph1NDc3nA1CJzdsagMx++iqY23qftqgUo0rKN9WDz2wmr/Q==
+liquidjs-lib@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.1.tgz#34c01329617c7ea7a0407b6304644740bb331b19"
+  integrity sha512-1JwoRwh3SpV8k9M5EAHLzn84rxHEhTb3XBWerDPJiwyPhK9u2VOZ+vtrFCn6CQ7PSo/takkRbDW+cdyFeAFFKA==
   dependencies:
+    "@types/randombytes" "^2.0.0"
+    "@types/wif" "^2.0.2"
     "@vulpemventures/secp256k1-zkp" "^2.0.0"
     axios "^0.21.1"
-    bech32 "^1.1.2"
+    bech32 "^2.0.0"
     bip174-liquid "^1.0.3"
     bip32 "^2.0.4"
     bip66 "^1.1.0"
     bitcoin-ops "^1.4.0"
-    blech32 "^1.0.1"
+    blech32 "^1.1.0"
     bs58check "^2.0.0"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.3"
-    merkle-lib "^2.0.10"
-    pushdata-bitcoin "^1.0.1"
-    randombytes "^2.0.1"
-    tiny-secp256k1 "^1.1.1"
+    create-hash "^1.2.0"
+    ecpair "^2.0.1"
     typeforce "^1.11.3"
-    varuint-bitcoin "^1.0.4"
+    varuint-bitcoin "^1.1.2"
     wif "^2.0.1"
 
 loader-runner@^2.4.0:
@@ -5651,11 +5691,6 @@ merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
-merkle-lib@^2.0.10:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/merkle-lib/-/merkle-lib-2.0.10.tgz#82b8dbae75e27a7785388b73f9d7725d0f6f3326"
-  integrity sha1-grjbrnXieneFOItz+ddyXQ9vMyY=
 
 micromatch@4.x, micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
@@ -6824,13 +6859,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pushdata-bitcoin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz#15931d3cd967ade52206f523aa7331aef7d43af7"
-  integrity sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=
-  dependencies:
-    bitcoin-ops "^1.3.0"
-
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -7998,7 +8026,14 @@ tiny-glob@^0.2.6:
     globalyzer "0.1.0"
     globrex "^0.1.2"
 
-tiny-secp256k1@^1.1.1, tiny-secp256k1@^1.1.3:
+tiny-secp256k1@*, tiny-secp256k1@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz#a61d4791b7031aa08a9453178a131349c3e10f9b"
+  integrity sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==
+  dependencies:
+    uint8array-tools "0.0.7"
+
+tiny-secp256k1@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz#7e224d2bee8ab8283f284e40e6b4acb74ffe047c"
   integrity sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==
@@ -8273,6 +8308,11 @@ typescript@^3.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
+uint8array-tools@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/uint8array-tools/-/uint8array-tools-0.0.7.tgz#a7a2bb5d8836eae2fade68c771454e6a438b390d"
+  integrity sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==
+
 unbox-primitive@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
@@ -8429,7 +8469,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-varuint-bitcoin@^1.0.4:
+varuint-bitcoin@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz#e76c138249d06138b480d4c5b40ef53693e24e92"
   integrity sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==


### PR DESCRIPTION
bump to liquidjs 6.0.1

* several deps are introduced (mainly because removed in liquidjs-lib): ecpair, tiny-secp256k1.
* bip32.ts instances a new BIP32API (it comes from new version of bip32)
* LDK exports liquidjs's `AssetHash` util
* some update on liquidjs type imports (due to bitcoinjs merge)

@tiero please review