### PR TITLE
bump liquidjs-lib to 6.0.2-liquid.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "bip39": "^3.0.3",
     "bs58check": "^2.1.2",
     "ecpair": "^2.0.1",
-    "liquidjs-lib": "^6.0.1",
+    "liquidjs-lib": "^6.0.2-liquid.0",
     "marina-provider": "^1.0.0",
     "slip77": "^0.2.0",
     "tiny-secp256k1": "^2.2.1",

--- a/src/ecpair.ts
+++ b/src/ecpair.ts
@@ -1,0 +1,4 @@
+import ECPairFactory from 'ecpair';
+import * as ecc from 'tiny-secp256k1';
+
+export const ECPair = ECPairFactory(ecc);

--- a/src/explorer/utxos.ts
+++ b/src/explorer/utxos.ts
@@ -1,4 +1,5 @@
-import { ECPair, address } from 'liquidjs-lib';
+import { address } from 'liquidjs-lib';
+import { ECPair } from '../ecpair';
 import UnblindError from '../error/unblind-error';
 import {
   AddressInterface,

--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -1,6 +1,7 @@
 import { BIP32Interface } from 'bip32';
 import * as bip39 from 'bip39';
-import { ECPair, Psbt, networks } from 'liquidjs-lib';
+import { Psbt, networks } from 'liquidjs-lib';
+import { ECPair } from '../ecpair';
 import { Network } from 'liquidjs-lib/src/networks';
 import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import { Slip77Interface } from 'slip77';

--- a/src/identity/multisig.ts
+++ b/src/identity/multisig.ts
@@ -1,6 +1,7 @@
 import { BIP32Interface } from 'bip32';
 import { mnemonicToSeedSync } from 'bip39';
-import { address, ECPair, networks, Psbt } from 'liquidjs-lib';
+import { address, networks, Psbt } from 'liquidjs-lib';
+import { ECPair } from '../ecpair';
 import { Network } from 'liquidjs-lib/src/networks';
 import { bip32 } from '../bip32';
 

--- a/src/identity/privatekey.ts
+++ b/src/identity/privatekey.ts
@@ -1,6 +1,7 @@
 import { ECPairInterface } from 'ecpair';
-import { ECPair, Psbt, payments } from 'liquidjs-lib';
+import { Psbt, payments } from 'liquidjs-lib';
 import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
+import { ECPair } from '../ecpair';
 
 import { AddressInterface, IdentityType } from '../types';
 import { checkIdentityType } from '../utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { networks, address, payments, ECPair, AssetHash } from 'liquidjs-lib';
+export { networks, address, payments, AssetHash } from 'liquidjs-lib';
 
 export * from './identity/identity';
 export * from './identity/mnemonic';
@@ -27,3 +27,4 @@ export * from './restorer/restorer';
 
 export * from './bip32';
 export * from './slip77';
+export * from './ecpair';

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
-import { address, ECPair, networks } from 'liquidjs-lib';
+import { address, networks } from 'liquidjs-lib';
+import { ECPair } from '../src/ecpair';
 
 import {
   AddressInterface,

--- a/test/fixtures/wallet.keys.ts
+++ b/test/fixtures/wallet.keys.ts
@@ -1,5 +1,6 @@
-import { networks, payments, ECPair } from 'liquidjs-lib';
+import { networks, payments } from 'liquidjs-lib';
 import { Mnemonic } from '../../src/identity/mnemonic';
+import { ECPair } from '../../src/ecpair';
 
 const network = networks.regtest;
 // generate a random keyPair for bob

--- a/test/privatekey.identity.test.ts
+++ b/test/privatekey.identity.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
 import {
-  ECPair,
   Psbt,
   Transaction,
   confidential,
@@ -9,6 +8,7 @@ import {
   address,
   AssetHash,
 } from 'liquidjs-lib';
+import { ECPair } from '../src/ecpair';
 
 import {
   AddressInterface,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5432,10 +5432,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-liquidjs-lib@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.1.tgz#34c01329617c7ea7a0407b6304644740bb331b19"
-  integrity sha512-1JwoRwh3SpV8k9M5EAHLzn84rxHEhTb3XBWerDPJiwyPhK9u2VOZ+vtrFCn6CQ7PSo/takkRbDW+cdyFeAFFKA==
+liquidjs-lib@^6.0.2-liquid.0:
+  version "6.0.2-liquid.0"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.0.tgz#cde6bed858d3b797c0076327ddc67a73892dfe61"
+  integrity sha512-ls8WOJRKq6d8550D/UXxIfzGPyWii2BwrTZhYZVPzZKx0Byf0/p4YLC1pColW6ouqxVWGcpCHXU/wY9t3cPy2A==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"


### PR DESCRIPTION
* bumps liquidjs-lib to 6.0.2-liquid.0
* creates and exports `ecpair.ts`
* updates import of ECPair

@tiero please review