### PR TITLE
Bump liquidjs-lib to `6.0.2-liquid.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "bip39": "^3.0.3",
     "bs58check": "^2.1.2",
     "ecpair": "^2.0.1",
-    "liquidjs-lib": "^6.0.2-liquid.0",
+    "liquidjs-lib": "^6.0.2-liquid.1",
     "marina-provider": "^1.0.0",
     "slip77": "^0.2.0",
     "tiny-secp256k1": "^2.2.1",

--- a/src/bip32.ts
+++ b/src/bip32.ts
@@ -1,5 +1,5 @@
 // bip32.ts use the factory from bip32 pkg + ecc to create a bip32 instance.
 import BIP32Factory from 'bip32';
-import * as ecc from 'tiny-secp256k1';
+import { ecc } from './ecclib';
 
 export const bip32 = BIP32Factory(ecc);

--- a/src/ecclib.ts
+++ b/src/ecclib.ts
@@ -1,0 +1,2 @@
+import * as ecclib from 'tiny-secp256k1';
+export const ecc = ecclib;

--- a/src/ecpair.ts
+++ b/src/ecpair.ts
@@ -1,4 +1,4 @@
 import ECPairFactory from 'ecpair';
-import * as ecc from 'tiny-secp256k1';
+import { ecc } from './ecclib';
 
 export const ECPair = ECPairFactory(ecc);

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -1,7 +1,13 @@
-import { Transaction, networks, confidential, TxOutput } from 'liquidjs-lib';
+import {
+  Transaction,
+  networks,
+  confidential,
+  TxOutput,
+  Psbt,
+} from 'liquidjs-lib';
 import { Network } from 'liquidjs-lib/src/networks';
 import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
-
+import { ecc } from '../ecclib';
 import { AddressInterface, NetworkString } from '../types';
 import { IdentityType } from '../types';
 import { isConfidentialOutput, psetToUnsignedHex, decodePset } from '../utils';
@@ -139,7 +145,12 @@ export class Identity {
       inputsData.set(index, blinders);
     }
 
-    const blinded = await pset.blindOutputsByIndex(inputsData, outputsKeys);
+    const blinded = await pset.blindOutputsByIndex(
+      Psbt.ECCKeysGenerator(ecc),
+      inputsData,
+      outputsKeys
+    );
+
     return blinded.toBase64();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { networks, address, payments, AssetHash } from 'liquidjs-lib';
+export * from 'liquidjs-lib';
 
 export * from './identity/identity';
 export * from './identity/mnemonic';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export * from './balance';
 export * from './restorer/mnemonic-restorer';
 export * from './restorer/restorer';
 
+export * from './ecclib';
 export * from './bip32';
 export * from './slip77';
 export * from './ecpair';

--- a/src/slip77.ts
+++ b/src/slip77.ts
@@ -1,4 +1,4 @@
 import { SLIP77Factory } from 'slip77';
-import * as ecc from 'tiny-secp256k1';
+import { ecc } from './ecclib';
 
 export const slip77 = SLIP77Factory(ecc);

--- a/test/mnemonic.identity.test.ts
+++ b/test/mnemonic.identity.test.ts
@@ -21,6 +21,7 @@ import {
   mnemonicRestorerFromState,
   StateRestorerOpts,
   slip77,
+  ecc,
 } from '../src';
 
 import { Restorer } from '../src';
@@ -166,7 +167,10 @@ describe('Identity: Mnemonic', () => {
       const signedPsbt = Psbt.fromBase64(signedBase64);
       let isValid = false;
       assert.doesNotThrow(
-        () => (isValid = signedPsbt.validateSignaturesOfAllInputs())
+        () =>
+          (isValid = signedPsbt.validateSignaturesOfAllInputs(
+            Psbt.ECDSASigValidator(ecc)
+          ))
       );
       assert.deepStrictEqual(isValid, true);
     });
@@ -228,7 +232,10 @@ describe('Identity: Mnemonic', () => {
       const signedPsbt = Psbt.fromBase64(signedBase64);
       let isValid = false;
       assert.doesNotThrow(
-        () => (isValid = signedPsbt.validateSignaturesOfAllInputs())
+        () =>
+          (isValid = signedPsbt.validateSignaturesOfAllInputs(
+            Psbt.ECDSASigValidator(ecc)
+          ))
       );
       assert.deepStrictEqual(isValid, true);
     });

--- a/test/multisig.identity.test.ts
+++ b/test/multisig.identity.test.ts
@@ -19,6 +19,7 @@ import {
   Multisig,
   multisigFromEsplora,
   DEFAULT_BASE_DERIVATION_PATH,
+  ecc,
 } from '../src';
 
 import { faucet, fetchTxHex, fetchUtxos, sleep } from './_regtest';
@@ -135,7 +136,10 @@ describe('Identity:  Multisig', () => {
       const signedPsbt = Psbt.fromBase64(signedBase64);
       let isValid = false;
       assert.doesNotThrow(
-        () => (isValid = signedPsbt.validateSignaturesOfAllInputs())
+        () =>
+          (isValid = signedPsbt.validateSignaturesOfAllInputs(
+            Psbt.ECDSASigValidator(ecc)
+          ))
       );
       assert.deepStrictEqual(isValid, true);
     });
@@ -198,7 +202,10 @@ describe('Identity:  Multisig', () => {
       const signedPsbt = Psbt.fromBase64(signedBase64);
       let isValid = false;
       assert.doesNotThrow(
-        () => (isValid = signedPsbt.validateSignaturesOfAllInputs())
+        () =>
+          (isValid = signedPsbt.validateSignaturesOfAllInputs(
+            Psbt.ECDSASigValidator(ecc)
+          ))
       );
       assert.deepStrictEqual(isValid, true);
     });

--- a/test/privatekey.identity.test.ts
+++ b/test/privatekey.identity.test.ts
@@ -12,6 +12,7 @@ import { ECPair } from '../src/ecpair';
 
 import {
   AddressInterface,
+  ecc,
   IdentityOpts,
   IdentityType,
   PrivateKey,
@@ -104,7 +105,10 @@ describe('Identity: Private key', () => {
       const signedPsbt = Psbt.fromBase64(signedBase64);
       let isValid = false;
       assert.doesNotThrow(
-        () => (isValid = signedPsbt.validateSignaturesOfAllInputs())
+        () =>
+          (isValid = signedPsbt.validateSignaturesOfAllInputs(
+            Psbt.ECDSASigValidator(ecc)
+          ))
       );
       assert.deepStrictEqual(isValid, true);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5432,10 +5432,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-liquidjs-lib@^6.0.2-liquid.0:
-  version "6.0.2-liquid.0"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.0.tgz#cde6bed858d3b797c0076327ddc67a73892dfe61"
-  integrity sha512-ls8WOJRKq6d8550D/UXxIfzGPyWii2BwrTZhYZVPzZKx0Byf0/p4YLC1pColW6ouqxVWGcpCHXU/wY9t3cPy2A==
+liquidjs-lib@^6.0.2-liquid.1:
+  version "6.0.2-liquid.1"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.1.tgz#21f09efb9c6545951a0263c66d44955461f3e12b"
+  integrity sha512-bWO0HUa42ZSq4zFY5yeo8ELQ8gQsPlCQ7Pyx/qTjVpka/cFdeUCe3VvFtfrKhpwBee/WW5vv7+WfbdaJfJ1Drg==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"


### PR DESCRIPTION
This PR updates LDK with the new changes of liquidjs-lib.

* create a new `ecclib` file: this is basically the `TinySecp256k1Interface` used by "injected libs" (bip32, slip77, bip341...)
* re-export `ecc` from `ecclib` -> the idea is to let the user re-use the **LDK version of tiny-secp256k1** if needed.
* re-export all from `liquidjs-lib`: it closes #66 
* updates some Psbt methods in tests in order to fix the new liquidjs breaking changes.

---
The idea is to simplify the "import process" because we often use liquidjs + LDK. Moreover, the new 'injected logic' for ecc lib could complexify the thing. With the PR changes, importing **only ldk in a project let you**:
* do not manage ecclib injection in bip32 & slip77
* access all the LDK methods
* access all the liquidjs methods and classes **from ldk** (so no need to handle the liquidjs-lib version)
* access your ldk's ecclib (if u want to re-inject it elsewhere) 


please review @tiero 