### PR TITLE
liquidjs `6.0.2-liquid.5` update

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,7 @@
     "bip39": "^3.0.3",
     "bs58check": "^2.1.2",
     "ecpair": "^2.0.1",
-    "liquidjs-lib": "^6.0.2-liquid.1",
-    "marina-provider": "^1.0.0",
+    "liquidjs-lib": "^6.0.2-liquid.5",
     "slip77": "^0.2.0",
     "tiny-secp256k1": "^2.2.1",
     "tslib": "^2.3.1"

--- a/src/identity/browserinject.ts
+++ b/src/identity/browserinject.ts
@@ -1,9 +1,6 @@
 import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
-import { MarinaProvider } from 'marina-provider';
-
 import { AddressInterface, IdentityType } from '../types';
 import { checkIdentityType } from '../utils';
-
 import { Identity, IdentityInterface, IdentityOpts } from './identity';
 
 /**
@@ -14,9 +11,16 @@ export interface InjectOpts {
   windowProvider: string;
 }
 
+export interface BrowserInjectProviderInterface {
+  getNextAddress: () => Promise<AddressInterface>;
+  getNextChangeAddress: () => Promise<AddressInterface>;
+  getAddresses: () => Promise<AddressInterface[]>;
+  signTransaction: (psetBase64: string) => Promise<string>;
+}
+
 export class BrowserInject extends Identity implements IdentityInterface {
   // here we force MarinaProvider since there aren't other Liquid injected API specification available as TypeScript interface yet.
-  protected provider: MarinaProvider;
+  protected provider: BrowserInjectProviderInterface;
 
   constructor(args: IdentityOpts<InjectOpts>) {
     super(args);
@@ -34,6 +38,7 @@ export class BrowserInject extends Identity implements IdentityInterface {
       );
     }
 
+    // the provider must implement BrowserInjectProviderInterface
     this.provider = (window as any)[args.opts.windowProvider];
   }
 

--- a/src/identity/masterpubkey.ts
+++ b/src/identity/masterpubkey.ts
@@ -4,7 +4,6 @@ import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import { Slip77Interface } from 'slip77';
 import { bip32 } from '../bip32';
 import { slip77 } from '../slip77';
-
 import { AddressInterface, IdentityType } from '../types';
 import {
   checkIdentityType,
@@ -12,7 +11,6 @@ import {
   isValidXpub,
   toXpub,
 } from '../utils';
-
 import { Identity, IdentityInterface, IdentityOpts } from './identity';
 
 export interface MasterPublicKeyOpts {

--- a/src/identity/multisigWatchOnly.ts
+++ b/src/identity/multisigWatchOnly.ts
@@ -4,7 +4,6 @@ import { networks } from 'liquidjs-lib';
 import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import { Slip77Interface } from 'slip77';
 import { bip32 } from '../bip32';
-
 import { blindingKeyFromXPubs, p2msPayment } from '../p2ms';
 import {
   AddressInterface,
@@ -14,7 +13,6 @@ import {
 } from '../types';
 import { IdentityType } from '../types';
 import { checkIdentityType, checkMasterPublicKey, toXpub } from '../utils';
-
 import { IdentityInterface, IdentityOpts } from './identity';
 import { Identity } from './identity';
 

--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -2,7 +2,6 @@ import axios from 'axios';
 import { IdentityInterface } from '../identity/identity';
 import { Multisig } from '../identity/multisig';
 import { MultisigWatchOnly } from '../identity/multisigWatchOnly';
-
 import { MasterPublicKey } from './../identity/masterpubkey';
 import { Mnemonic } from './../identity/mnemonic';
 import { Restorer } from './restorer';
@@ -17,7 +16,7 @@ export interface EsploraRestorerOpts {
   gapLimit: number;
 }
 
-function restorerFromEsplora<R extends IdentityInterface>(
+export function restorerFromEsplora<R extends IdentityInterface>(
   identity: R,
   getAddress: (isChange: boolean, index: number) => string
 ): Restorer<EsploraRestorerOpts, R> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface AddressInterface {
   blindingPrivateKey: string;
   derivationPath?: string;
   publicKey?: string;
+  [key: string]: any;
 }
 
 // define a type using to implement change's address strategy

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,10 +2183,10 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blech32@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/blech32/-/blech32-1.1.0.tgz#3f7ad05e18f36db2162cb5e8acf603fdd8a3d793"
-  integrity sha512-TGl9OgRq7woBzhQX1S5Im7opgyb2lpnEgqoApHpEZ8hgo8NSQkwJrf1Qxbg6frobTdBWxo2c+sFLjZFWGMLZHA==
+blech32@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/blech32/-/blech32-1.1.1.tgz#b3260d953710c25a2bdac08bfe919d0db1cb3203"
+  integrity sha512-5EvwgaKzsUMU9En0aAum5Gq48Gp40ODxUZTAPK5gg5BNxjkjDve3Qh/yLEg33wYEaNXL3IFRsnQoky5+bA9tLQ==
   dependencies:
     long "^4.0.0"
 
@@ -5432,10 +5432,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-liquidjs-lib@^6.0.2-liquid.1:
-  version "6.0.2-liquid.1"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.1.tgz#21f09efb9c6545951a0263c66d44955461f3e12b"
-  integrity sha512-bWO0HUa42ZSq4zFY5yeo8ELQ8gQsPlCQ7Pyx/qTjVpka/cFdeUCe3VvFtfrKhpwBee/WW5vv7+WfbdaJfJ1Drg==
+liquidjs-lib@^6.0.2-liquid.5:
+  version "6.0.2-liquid.5"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.5.tgz#075f1b9d0152d832880806853e56249ae9cca885"
+  integrity sha512-9zaEGC7q+ermW9Zo3ia7CCOD2S7TfQlXynL5AumepMeG3NsmioIVp+nobC4NDAphUC5/56HRsu54M4hpqgkRtw==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"
@@ -5446,7 +5446,7 @@ liquidjs-lib@^6.0.2-liquid.1:
     bip32 "^2.0.4"
     bip66 "^1.1.0"
     bitcoin-ops "^1.4.0"
-    blech32 "^1.1.0"
+    blech32 "^1.1.1"
     bs58check "^2.0.0"
     create-hash "^1.2.0"
     ecpair "^2.0.1"
@@ -5646,11 +5646,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-marina-provider@^1.0.0:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.3.tgz#15e51c989569e96088a74916ff195e03fc0b05c8"
-  integrity sha512-FXeJ61q+arMUEdR7GeXLmT/Xx8w1NP5vmkztkBIeSmRFvs02qjJO6GqutEUnVFWUzC3QQSB45yiOo8+i8ohYZw==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
**no breaking changes**

- bumps to latest liquidjs-lib `6.0.2-liquid.5` (fix taproot pset).
- remove `marina-provider` dep, the type `MarinaProvider` has been replaced by a new `BrowserInjectProviderInterface`.
- extend `AddressInterface` type & export explora restorer function from `restorer.ts` (let to extend IdentityInterface in upper projects).

@tiero please review