### PR TITLE
add descriptors module + script-analyzer.ts

### DIFF
--- a/src/descriptors/ast.ts
+++ b/src/descriptors/ast.ts
@@ -1,0 +1,226 @@
+import { bip341 } from 'liquidjs-lib';
+
+export enum TypeAST {
+  SCRIPT = 0, // one of ScriptType
+  TREE, // {asm(...)|TREE,asm(...)|TREE}
+  HEX, // ? bits hex
+  KEY, // 64 bits hex
+}
+
+export enum ScriptType {
+  ELTR = 'eltr', // eltr(KEY, TREE)
+  ASM = 'asm', // asm(STRING)
+  RAW = 'raw', // raw(HEX)
+}
+
+const numOfChildren = new Map<ScriptType, number>()
+  .set(ScriptType.ELTR, 2)
+  .set(ScriptType.ASM, 1)
+  .set(ScriptType.RAW, 1);
+
+// Abstract syntax tree
+export interface AST<V = any> {
+  type: TypeAST;
+  value: V;
+  children: AST[];
+}
+
+export interface DescriptorsCompilerAPI {
+  compile: (ast: AST) => TemplateResult;
+}
+
+// (template string, context) --parser--> AST --compiler--> Result object
+export interface TemplateResult {
+  scriptPubKey(): Buffer; // the address' script
+  redeemScript?(): Buffer; // optional, only if needed to spend the scriptPubKey (e.g. for P2SH, P2WSH, P2WSH-P2SH...)
+  // optional, returns witnesses needed to spend the scriptPubKey
+  // in case of segwit v0 = [redeemScript()]
+  // in case of segwit v1 = [leafScript, taprootControlBlock]
+  witnesses?(...args: any[]): Buffer[];
+  taprootHashTree?: bip341.HashTree; // optional, should be undefined if not an eltr template
+  taprootInternalKey?: string; // optional, should be undefined if not an eltr template
+}
+
+const withoutEccCompilers = new Map([
+  [ScriptType.RAW, compileRAW],
+  [ScriptType.ASM, compileASM],
+]);
+
+function compileFromEcc(ecc: bip341.TinySecp256k1Interface) {
+  // map cmd to compile functions
+  const compilers = withoutEccCompilers.set(
+    ScriptType.ELTR,
+    makeCompileELTR(bip341.BIP341Factory(ecc))
+  );
+
+  return (ast: AST): TemplateResult => {
+    return compileScript(ast, compilers, true);
+  };
+}
+
+export const DescriptorsCompilerFactory = (
+  ecc: bip341.TinySecp256k1Interface
+): DescriptorsCompilerAPI => {
+  return {
+    compile: compileFromEcc(ecc),
+  };
+};
+
+function checkScriptNode(ast: AST, scriptType: ScriptType): void {
+  if (ast.type !== TypeAST.SCRIPT) {
+    throw new Error('Expected script node');
+  }
+
+  if (ast.value !== scriptType) {
+    throw new Error(`Expected ${scriptType} script`);
+  }
+
+  if (ast.children.length !== numOfChildren.get(ast.value)) {
+    throw new Error(
+      `Expected script node ${ast.type} with ${numOfChildren.get(
+        ast.value
+      )} of children`
+    );
+  }
+}
+
+function compileHEX(ast: AST): TemplateResult {
+  if (ast.type !== TypeAST.HEX) {
+    throw new Error('Expected hex node');
+  }
+
+  if (typeof ast.value !== 'string')
+    throw new Error('Expected hex node with string value');
+  const script = Buffer.from(ast.value, 'hex');
+  return {
+    scriptPubKey: () => script,
+  };
+}
+
+// 'raw' node
+function compileRAW(ast: AST): TemplateResult {
+  checkScriptNode(ast, ScriptType.RAW);
+  return compileHEX(ast.children[0]);
+}
+
+// 'asm' node, which is a subset of raw
+function compileASM(ast: AST): TemplateResult {
+  checkScriptNode(ast, ScriptType.ASM);
+  return compileHEX(ast.children[0]);
+}
+
+// this is not a ScriptCompileFunction
+// recursive way to get all the leaves of the tree
+function compileTREE(ast: AST): bip341.TaprootLeaf[] {
+  if (ast.type !== TypeAST.TREE) {
+    throw new Error('Expected tree node');
+  }
+
+  const leaves: bip341.TaprootLeaf[] = [];
+  if (ast.children.length < 1 || ast.children.length > 2) {
+    throw new Error('Expected tree node with 1 or 2 leaves');
+  }
+
+  for (const child of ast.children) {
+    switch (child.type) {
+      case TypeAST.SCRIPT:
+        leaves.push({
+          scriptHex: compileScript(child, withoutEccCompilers) // we do not expect any toplevel compilers so we can use withoutEccCompilers
+            .scriptPubKey()
+            .toString('hex'),
+        });
+        break;
+      case TypeAST.TREE:
+        leaves.push(...compileTREE(child));
+        break;
+      default:
+        throw new Error(
+          `Expected tree node with children of type ${TypeAST.SCRIPT} or ${TypeAST.TREE}`
+        );
+    }
+  }
+
+  return leaves;
+}
+
+function compileKEY(ast: AST): Buffer {
+  if (ast.type !== TypeAST.KEY) {
+    throw new Error('Expected key node');
+  }
+
+  if (typeof ast.value !== 'string' && ast.value.length === 64)
+    throw new Error('Expected key (64 hex chars)');
+  return Buffer.from(ast.value, 'hex');
+}
+
+function makeCompileELTR(bip341lib: bip341.BIP341API) {
+  return function(ast: AST): TemplateResult {
+    checkScriptNode(ast, ScriptType.ELTR);
+
+    if (ast.children[0].type !== TypeAST.KEY) {
+      throw new Error('Expected KEY as first argument of eltr');
+    }
+
+    if (ast.children[1].type !== TypeAST.TREE) {
+      throw new Error('Expected TREE as second argument of eltr');
+    }
+
+    const internalKey = compileKEY(ast.children[0]);
+    const leaves = compileTREE(ast.children[1]);
+
+    const tree = bip341.toHashTree(leaves, true);
+    // this is a trick for the bip341 functions (accept only prefixed keys)
+    const prefixedInternalKey = Buffer.concat([Buffer.of(0x00), internalKey]);
+
+    // segwit v1 scriptPubKey
+    const scriptPubKey = bip341lib.taprootOutputScript(
+      prefixedInternalKey,
+      tree
+    );
+
+    return {
+      witnesses: (leafScript: string): Buffer[] => {
+        const leaf = leaves.find(l => l.scriptHex === leafScript);
+        if (!leaf) {
+          throw new Error(
+            'Could not find leaf script for script ' + leafScript
+          );
+        }
+
+        const path = bip341.findScriptPath(tree, bip341.tapLeafHash(leaf));
+        return bip341lib.taprootSignScriptStack(
+          prefixedInternalKey,
+          leaf,
+          tree.hash,
+          path
+        );
+      },
+      scriptPubKey: () => scriptPubKey,
+      taprootHashTree: tree,
+      taprootInternalKey: internalKey.toString('hex'),
+    };
+  };
+}
+
+const topLevelOnly = [ScriptType.RAW, ScriptType.ELTR];
+
+type CompilersMap = Map<ScriptType, ScriptCompileFunction>;
+type ScriptCompileFunction = (ast: AST) => TemplateResult;
+
+// main compile function
+function compileScript(
+  ast: AST,
+  compilersMap: CompilersMap,
+  isTop = false
+): TemplateResult {
+  const compileFunction = compilersMap.get(ast.value);
+  if (!compileFunction) {
+    throw new Error(`node type: ${ast.type} is not a descriptor`);
+  }
+
+  if (!isTop && topLevelOnly.includes(ast.value)) {
+    throw new Error(`node type: ${ast.value} is a top level only descriptor`);
+  }
+
+  return compileFunction(ast);
+}

--- a/src/descriptors/doc.md
+++ b/src/descriptors/doc.md
@@ -1,0 +1,80 @@
+# Marina output descriptors template
+
+The `descriptors` package extends [the original syntax of output script descriptors](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).
+
+Giving a string template, the `evaluate` function is able to compute:
+
+- redeem script
+- witness scripts if needed (the unsigned part of the witness).
+
+The descriptor is also able to replace special tokens (named "namespace") by a public key. It lets to link template with marina covenant accounts (identitfied by their namespace).
+
+## Example
+
+Assuming `vulpem` is one of the Marina accounts, and given the following template:
+
+```
+elp2wsh(asm($vulpem OP_CHECKSIG))
+```
+
+Marina will creates a `Context` object mapping each `$vulpem` in the template to their actual derivation path:
+
+- in case of signing an input: the path equals the one of the utxo.
+- in case of create a new address: the path equals the one of the next address.
+
+Then calling `evaluate` we are able to get our witness script and redeem script:
+
+> The `result` object value depends on the Context!
+
+## API
+
+All descriptors can accept `xpub...` token, the public keys are replaced before parsing the template.
+
+### Raw
+
+Expects an hex string as input.
+
+```
+raw(010203)
+```
+
+Returns the hex string in raw as `redeemScript` when evaluated, do not create any witness.
+
+### Asm
+
+Expects Bitcoin ASM script as input.
+
+```
+asm(OP_DUP OP_HASH160 0123456 OP_EQUALVERIFY OP_CHECKSIG)
+```
+
+Returns the hex value of the script as `redeemScript`. Do not create any witness.
+
+### Elp2wsh
+
+It lets to create a segwit v0 script. It expects another descriptor returning a `redeemScript` as input. Often used with `raw` or `asm`:
+
+```
+elp2wsh(raw(0123456789))
+```
+
+Returns:
+
+- `raw(0123456789)` redeem script as `witnesses`.
+- the segwit v0 script `(OP_0 + hash(raw(0123456789)))` as `redeemScript`.
+
+### Eltr
+
+It lets to create [P2TR](https://en.bitcoin.it/wiki/Taproot) payments. The descripor expects 2 inputs:
+
+1. The internal taproot public key. This can be replaced by an `xpub` token in order to increment it according to actual derivation path. Will fail if this is not a 64bits hex string.
+2. A script tree which can be either (a) any descriptors or (b) an open brace `{`, another script tree, a comma `,` a script tree and a closing brace `}`.
+
+```
+eltr(c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5, {raw(0123456789),asm(OP_TRUE)})
+```
+
+Returns:
+
+- segwit v1 script as `redeemScript`.
+- As the value of the witness depends on the script leaf used to spend the script, we don't return an array of static witnesses like the other descriptors. Instead, we return a function `getWitnesses(leafScript: string)` allowing the calculation of witnesses for the leaf with script = `leafScript`.

--- a/src/descriptors/index.ts
+++ b/src/descriptors/index.ts
@@ -1,0 +1,50 @@
+import { bip341 } from 'liquidjs-lib';
+import { DescriptorsCompilerFactory, TemplateResult } from './ast';
+import { parseSCRIPT } from './parser';
+import { Context, findNamespaces, preprocessor } from './preprocessing';
+export { Context, TemplateResult };
+
+/**
+ * evaluate a template string and return witness scripts and redeem script associated with it
+ * @param ctx used to replace xpubs with their current derivated public keys
+ * @param template the string to evaluate
+ **/
+
+export function makeEvaluateDescriptor(ecc: bip341.TinySecp256k1Interface) {
+  const compile = DescriptorsCompilerFactory(ecc).compile;
+  return function(ctx: Context, template: string): TemplateResult {
+    const processedTemplate = preprocessor(ctx, template);
+    const [ast] = parseSCRIPT(processedTemplate);
+    if (!ast) throw new Error('Failed to parse template');
+    return compile(ast);
+  };
+}
+
+/**
+ * validate can be used without a context object to validate the parsability of a template string
+ * @param template the template string to validate
+ * @returns true if template is OK, false otherwise
+ */
+export function validate(template: string): boolean {
+  const namespaces = findNamespaces(template);
+  if (namespaces.length > 0) {
+    const fakeKey = Buffer.alloc(32).toString('hex');
+    const fakeCtx: Context = {
+      namespaces: new Map(),
+    };
+
+    for (const namespace of namespaces) {
+      fakeCtx.namespaces.set(namespace, { pubkey: fakeKey });
+    }
+
+    template = preprocessor(fakeCtx, template);
+  }
+
+  try {
+    const [ast] = parseSCRIPT(template);
+    if (!ast) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/descriptors/parser.ts
+++ b/src/descriptors/parser.ts
@@ -1,0 +1,136 @@
+import { script } from 'liquidjs-lib';
+import { ScriptType, TypeAST, AST } from './ast';
+import { readHex, readUntil } from './utils';
+
+const EXPECT_TOKEN = (token: string) => new Error(`Expected ${token}`);
+
+function cmd(type: ScriptType): string {
+  return type.toString();
+}
+
+type Parser = (text: string) => [AST | undefined, string];
+
+function compose(...parsers: Parser[]): Parser {
+  return (text: string) => {
+    let result: AST | undefined;
+    let remainingText = text.trimStart();
+    for (const parser of parsers) {
+      const [child, text] = parser(remainingText);
+      if (child) {
+        if (result) {
+          result.children.push(child);
+        } else {
+          result = child;
+        }
+      }
+      remainingText = text.trimStart();
+    }
+
+    return [result, remainingText];
+  };
+}
+
+function oneOf(...parsers: Parser[]): Parser {
+  const errors: Error[] = [];
+  return (text: string) => {
+    for (const parser of parsers) {
+      try {
+        return parser(text);
+      } catch (e) {
+        // ignore
+        if (e instanceof Error) {
+          errors.push(e);
+        }
+      }
+    }
+
+    throw new Error(`one of: ${errors.map(e => e.message).join(', ')}`);
+  };
+}
+
+const parseHEX: Parser = (text: string) => {
+  const [hex, remainingText] = readHex(text);
+  return [{ type: TypeAST.HEX, value: hex, children: [] }, remainingText];
+};
+
+const parseKEY: Parser = (text: string) => {
+  const [hex, remainingText] = readHex(text);
+  if (hex.length !== 64) {
+    throw EXPECT_TOKEN('key (hex string with len=64)');
+  }
+
+  return [{ type: TypeAST.KEY, value: hex, children: [] }, remainingText];
+};
+
+const parseASMScript: Parser = (text: string) => {
+  const [str, remainingText] = readUntil(text, ')');
+  const asmScript = script.fromASM(str);
+  return [
+    { type: TypeAST.HEX, value: asmScript.toString('hex'), children: [] },
+    remainingText,
+  ];
+};
+
+// parse a token, does not create any AST node
+const parseToken = (token: string): Parser => (text: string) => {
+  if (text.startsWith(token)) {
+    return [undefined, text.slice(token.length)];
+  }
+
+  throw EXPECT_TOKEN(token);
+};
+
+const parseTreeToken: Parser = (text: string) => {
+  const [, remainingText] = parseToken('{')(text);
+  return [
+    { type: TypeAST.TREE, value: undefined, children: [] },
+    remainingText,
+  ];
+};
+
+// tree parser
+const parseTREE: Parser = (text: string) => {
+  if (text.startsWith('{')) {
+    return compose(
+      parseTreeToken,
+      parseTREE,
+      parseComma,
+      parseTREE,
+      parseToken('}')
+    )(text);
+  }
+
+  return parseSCRIPT(text);
+};
+
+const parseScriptToken = (type: ScriptType): Parser => (text: string) => {
+  const res = compose(parseToken(cmd(type)), parseToken('('))(text);
+  return [{ type: TypeAST.SCRIPT, value: type, children: [] }, res[1]];
+};
+
+const parseEndCmd = parseToken(')');
+const parseComma = parseToken(',');
+
+export const parseSCRIPT: Parser = (text: string) => {
+  return oneOf(parseASM, parseRAW, parseELTR)(text);
+};
+
+const parseRAW = compose(
+  parseScriptToken(ScriptType.RAW), // raw(
+  parseHEX, // hex of any length
+  parseEndCmd // ')'
+);
+
+const parseELTR = compose(
+  parseScriptToken(ScriptType.ELTR), // eltr(
+  parseKEY, // 64 hex chars
+  parseComma, // ','
+  parseTREE, // TREE
+  parseEndCmd // ')'
+);
+
+const parseASM = compose(
+  parseScriptToken(ScriptType.ASM), // asm(
+  parseASMScript, // opcodes
+  parseEndCmd // ')'
+);

--- a/src/descriptors/preprocessing.ts
+++ b/src/descriptors/preprocessing.ts
@@ -1,0 +1,42 @@
+const namespaceRegexp = /[$][a-z]+/;
+
+export interface Context {
+  // map namespace token to public key
+  namespaces: Map<string, { pubkey: string }>;
+}
+
+function replaceAll(str: string, find: string, replace: string): string {
+  return str.split(find).join(replace);
+}
+
+export function findNamespaces(text: string): Array<string> {
+  const namespaces = namespaceRegexp.exec(text);
+  if (!namespaces) return [];
+  return namespaces.map(n => n.slice(1)); // remove the '$' token
+}
+
+export function processNamespaces(
+  ctx: Context['namespaces'],
+  text: string
+): string {
+  const namespaces = findNamespaces(text);
+  if (!namespaces.length) return text;
+
+  let processedText = text;
+  for (const namespace of namespaces) {
+    const namespacePublicKey = ctx.get(namespace)?.pubkey;
+    if (!namespacePublicKey)
+      throw new Error(`Could not find namespace context: ${namespace}`);
+    processedText = replaceAll(
+      processedText,
+      '$' + namespace,
+      namespacePublicKey
+    );
+  }
+
+  return processedText;
+}
+
+export function preprocessor(ctx: Context, text: string): string {
+  return processNamespaces(ctx.namespaces, text);
+}

--- a/src/descriptors/utils.ts
+++ b/src/descriptors/utils.ts
@@ -1,0 +1,21 @@
+const hexRegExp = /^([A-Fa-f0-9]{2})+/;
+
+export function readHex(text: string): [string, string] {
+  return readWithRegExp(hexRegExp, text);
+}
+
+function readWithRegExp(regexp: RegExp, text: string): [string, string] {
+  const match = text.match(regexp);
+  if (!match) {
+    return ['', text];
+  }
+  return [match[0], text.slice(match[0].length)];
+}
+
+export function readUntil(text: string, char: string): [string, string] {
+  const index = text.indexOf(char);
+  if (index === -1) {
+    throw new Error(`Expected ${char}`);
+  }
+  return [text.slice(0, index), text.slice(index)];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,6 @@ export * from './balance';
 
 export * from './restorer/mnemonic-restorer';
 export * from './restorer/restorer';
+
+export * from './script-analyser';
+export * from './descriptors';

--- a/src/script-analyser.ts
+++ b/src/script-analyser.ts
@@ -1,0 +1,265 @@
+import { script } from 'liquidjs-lib';
+import { bip341 } from 'liquidjs-lib';
+
+// analyse a script to know what it need as input
+const { OPS } = script;
+
+interface SignatureNeed {
+  pubkey: string;
+}
+
+/**
+ * Script input need is the object representing the need of inputs for a script
+ * The current version can be improved: now it doesn't take into account the order of the inputs
+ * `sigs` describes the need of signatures
+ * `introspection` is a boolean indicating if the script contains any introspection opcodes
+ * `needParameters` is a boolean indicating if the script needs parameters extra parameter (excluding CHECKSIG)
+ */
+export interface ScriptInputsNeeds {
+  sigs: SignatureNeed[];
+  hasIntrospection: boolean;
+  needParameters: boolean;
+}
+
+const NEED_PARAMS_OPCODES = [
+  OPS.OP_PUSHDATA1,
+  OPS.OP_PUSHDATA2,
+  OPS.OP_PUSHDATA4,
+  OPS.OP_1NEGATE,
+  OPS.OP_RESERVED,
+  OPS.OP_IF,
+  OPS.OP_VERIF,
+  OPS.OP_VERNOTIF,
+  OPS.OP_ELSE,
+  OPS.OP_ENDIF,
+  OPS.OP_VERIFY,
+  OPS.OP_TOALTSTACK,
+  OPS.OP_FROMALTSTACK,
+  OPS.OP_2DROP,
+  OPS.OP_2DUP,
+  OPS.OP_3DUP,
+  OPS.OP_2OVER,
+  OPS.OP_2ROT,
+  OPS.OP_2SWAP,
+  OPS.OP_NIP,
+  OPS.OP_OVER,
+  OPS.OP_PICK,
+  OPS.OP_ROLL,
+  OPS.OP_ROT,
+  OPS.OP_SWAP,
+  OPS.OP_TUCK,
+  OPS.OP_CAT,
+  OPS.OP_SUBSTR,
+  OPS.OP_SUBSTR_LAZY,
+  OPS.OP_LEFT,
+  OPS.OP_RIGHT,
+  OPS.OP_SIZE,
+  OPS.OP_INVERT,
+  OPS.OP_AND,
+  OPS.OP_OR,
+  OPS.OP_XOR,
+  OPS.OP_EQUAL,
+  OPS.OP_EQUALVERIFY,
+  OPS.OP_RESERVED1,
+  OPS.OP_RESERVED2,
+  OPS.OP_1ADD,
+  OPS.OP_1SUB,
+  OPS.OP_2MUL,
+  OPS.OP_2DIV,
+  OPS.OP_NEGATE,
+  OPS.OP_ABS,
+  OPS.OP_NOT,
+  OPS.OP_0NOTEQUAL,
+  OPS.OP_ADD,
+  OPS.OP_SUB,
+  OPS.OP_MUL,
+  OPS.OP_DIV,
+  OPS.OP_MOD,
+  OPS.OP_LSHIFT,
+  OPS.OP_RSHIFT,
+  OPS.OP_BOOLAND,
+  OPS.OP_BOOLOR,
+  OPS.OP_NUMEQUAL,
+  OPS.OP_NUMEQUALVERIFY,
+  OPS.OP_NUMNOTEQUAL,
+  OPS.OP_LESSTHAN,
+  OPS.OP_GREATERTHAN,
+  OPS.OP_LESSTHANOREQUAL,
+  OPS.OP_GREATERTHANOREQUAL,
+  OPS.OP_MIN,
+  OPS.OP_MAX,
+  OPS.OP_WITHIN,
+  OPS.OP_RIPEMD160,
+  OPS.OP_SHA1,
+  OPS.OP_SHA256,
+  OPS.OP_HASH160,
+  OPS.OP_HASH256,
+  OPS.OP_CODESEPARATOR,
+  OPS.OP_CHECKMULTISIG,
+  OPS.OP_CHECKMULTISIGVERIFY,
+  OPS.OP_DETERMINISTICRANDOM,
+  OPS.OP_SHA256INITIALIZE,
+  OPS.OP_SHA256UPDATE,
+  OPS.OP_SHA256FINALIZE,
+  OPS.OP_ADD64,
+  OPS.OP_SUB64,
+  OPS.OP_MUL64,
+  OPS.OP_DIV64,
+  OPS.OP_NEG64,
+  OPS.OP_LESSTHAN64,
+  OPS.OP_LESSTHANOREQUAL64,
+  OPS.OP_GREATERTHAN64,
+  OPS.OP_GREATERTHANOREQUAL64,
+  OPS.OP_SCRIPTNUMTOLE64,
+  OPS.OP_LE64TOSCRIPTNUM,
+  OPS.OP_LE32TOLE64,
+  OPS.OP_ECMULSCALARVERIFY,
+  OPS.OP_TWEAKVERIFY,
+  OPS.OP_PUBKEYHASH,
+  OPS.OP_PUBKEY,
+  OPS.OP_INVALIDOPCODE,
+];
+
+const INTROSPECTION_OPCODES = [
+  OPS.OP_INSPECTINPUTOUTPOINT,
+  OPS.OP_INSPECTINPUTASSET,
+  OPS.OP_INSPECTINPUTVALUE,
+  OPS.OP_INSPECTINPUTSCRIPTPUBKEY,
+  OPS.OP_INSPECTINPUTSEQUENCE,
+  OPS.OP_INSPECTINPUTISSUANCE,
+  OPS.OP_PUSHCURRENTINPUTINDEX,
+  OPS.OP_INSPECTOUTPUTASSET,
+  OPS.OP_INSPECTOUTPUTVALUE,
+  OPS.OP_INSPECTOUTPUTNONCE,
+  OPS.OP_INSPECTOUTPUTSCRIPTPUBKEY,
+  OPS.OP_INSPECTVERSION,
+  OPS.OP_INSPECTLOCKTIME,
+  OPS.OP_INSPECTNUMINPUTS,
+  OPS.OP_INSPECTNUMOUTPUTS,
+];
+
+type NeedAnalyserFunction = (
+  stack: Buffer[]
+) => (pos: number) => ScriptInputsNeeds;
+
+function validatePosition(stack: Buffer[], pos: number) {
+  return !(pos < 0 || pos >= stack.length);
+}
+
+function mergeNeeds(...needs: ScriptInputsNeeds[]): ScriptInputsNeeds {
+  return {
+    sigs: needs.reduce(
+      (acc: ScriptInputsNeeds['sigs'], need) => acc.concat(need.sigs),
+      []
+    ),
+    hasIntrospection: needs.reduce(
+      (acc: ScriptInputsNeeds['hasIntrospection'], need) =>
+        acc || need.hasIntrospection,
+      false
+    ),
+    needParameters: needs.reduce(
+      (acc: ScriptInputsNeeds['needParameters'], need) =>
+        acc || need.needParameters,
+      false
+    ),
+  };
+}
+
+const needParametersAnalyser: NeedAnalyserFunction = stack => pos => {
+  if (!validatePosition(stack, pos))
+    throw new Error('Invalid position (NEED PARAM OPCODE)');
+  return {
+    sigs: [],
+    hasIntrospection: false,
+    needParameters: true,
+  };
+};
+
+const introspectionAnalyzer: NeedAnalyserFunction = stack => pos => {
+  if (!validatePosition(stack, pos))
+    throw new Error('invalid position (INTROSPECTION OPCODE)');
+  return {
+    sigs: [],
+    hasIntrospection: true,
+    needParameters: false,
+  };
+};
+
+const checksigAnalyzer: NeedAnalyserFunction = stack => pos => {
+  if (!validatePosition(stack, pos))
+    throw new Error('invalid position (CHECKSIG)');
+  if (!validatePosition(stack, pos - 1)) {
+    return {
+      sigs: [],
+      hasIntrospection: false,
+      needParameters: true,
+    };
+  }
+
+  const pubkey = stack[pos - 1];
+
+  return {
+    sigs: [{ pubkey: pubkey.toString('hex') }],
+    hasIntrospection: false,
+    needParameters: false,
+  };
+};
+
+const hex = (n: number) => Buffer.of(n).toString('hex');
+
+const ANALYZERS_BY_OPCODE = new Map<string, NeedAnalyserFunction>().set(
+  hex(OPS.OP_CHECKSIG),
+  checksigAnalyzer
+);
+
+INTROSPECTION_OPCODES.forEach(op =>
+  ANALYZERS_BY_OPCODE.set(hex(op), introspectionAnalyzer)
+);
+NEED_PARAMS_OPCODES.forEach(op =>
+  ANALYZERS_BY_OPCODE.set(hex(op), needParametersAnalyser)
+);
+
+function decompileScript(b: Buffer): Buffer[] {
+  const stack = script.decompile(b);
+  if (stack === null) throw new Error('malformed script');
+  return stack?.map(s => (Buffer.isBuffer(s) ? s : Buffer.of(s))) ?? [];
+}
+
+/**
+ * Analyze a script to know what it need as input
+ * @param scriptHex must be a valid Elements script
+ * @returns an object describing how to build the script inputs
+ */
+export function analyse(scriptHex: string): ScriptInputsNeeds {
+  const scriptBuffer = Buffer.from(scriptHex, 'hex');
+  const stack = decompileScript(scriptBuffer);
+
+  let needs: ScriptInputsNeeds = {
+    sigs: [],
+    hasIntrospection: false,
+    needParameters: false,
+  };
+
+  for (let i = 0; i < stack.length; i++) {
+    const elem = stack[i].toString('hex');
+    const analyser = ANALYZERS_BY_OPCODE.get(elem);
+    if (!analyser) continue;
+    needs = mergeNeeds(needs, analyser(stack)(i));
+  }
+
+  return needs;
+}
+
+export function analyzeTapscriptTree(
+  tree?: bip341.HashTree
+): Record<string, ScriptInputsNeeds> {
+  if (!tree) return {};
+  const children = {
+    ...(tree.left ? analyzeTapscriptTree(tree.left) : {}),
+    ...(tree.right ? analyzeTapscriptTree(tree.right) : {}),
+  };
+
+  if (tree.scriptHex)
+    return { ...children, [tree.scriptHex]: analyse(tree.scriptHex) };
+  return children;
+}

--- a/test/descriptors.spec.ts
+++ b/test/descriptors.spec.ts
@@ -1,0 +1,165 @@
+import {
+  Context,
+  makeEvaluateDescriptor,
+  script,
+  toXpub,
+  validate,
+} from '../src';
+import BIP32Factory from 'bip32';
+import * as ecc from 'tiny-secp256k1';
+import {
+  TypeAST,
+  ScriptType,
+  DescriptorsCompilerFactory,
+} from '../src/descriptors/ast';
+import { parseSCRIPT } from '../src/descriptors/parser';
+import { preprocessor } from '../src/descriptors/preprocessing';
+
+const compile = DescriptorsCompilerFactory(ecc).compile;
+const evaluate = makeEvaluateDescriptor(ecc);
+
+describe('evaluate', () => {
+  it('should replace namespace tokens', () => {
+    const xpub =
+      'vpub5SLqN2bLY4WeaAsje9qzuLmXM3DYdtxWYG2PipZAki3fbdCfpum3hf4ZVgigwfJGk3BT9KvSpUkqNEJhdHQjXdqjSRxYq7AETSXPjVH7UMq';
+    const text = `asm(OP_DUP OP_HASH160 $marina OP_EQUALVERIFY OP_CHECKSIG)`;
+    const key = BIP32Factory(ecc)
+      .fromBase58(toXpub(xpub))
+      .derivePath('0/1')
+      .publicKey.toString('hex');
+    const ctx: Context = {
+      namespaces: new Map().set('marina', { pubkey: key }),
+    };
+
+    const processedText = preprocessor(ctx, text);
+
+    expect(processedText).toEqual(
+      `asm(OP_DUP OP_HASH160 ${key} OP_EQUALVERIFY OP_CHECKSIG)`
+    );
+    const result = evaluate(ctx, text);
+    expect(result.scriptPubKey()).toEqual(
+      script.fromASM(`OP_DUP OP_HASH160 ${key} OP_EQUALVERIFY OP_CHECKSIG`)
+    );
+  });
+});
+
+describe('parser', () => {
+  it('should parse raw template', () => {
+    const text =
+      'raw(08e53a2e9e3ed3ba34dd5ce7f94e1e62abc3549e2d8796d8cd01102a23af1a)';
+    const [tree, remainingText] = parseSCRIPT(text);
+
+    expect(tree).toEqual({
+      type: TypeAST.SCRIPT,
+      value: ScriptType.RAW,
+      children: [
+        {
+          type: TypeAST.HEX,
+          value:
+            '08e53a2e9e3ed3ba34dd5ce7f94e1e62abc3549e2d8796d8cd01102a23af1a',
+          children: [],
+        },
+      ],
+    });
+    expect(remainingText).toEqual('');
+  });
+
+  it('should parse eltr template', () => {
+    const text =
+      'eltr(c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5,{asm(c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5 OP_CHECKSIG),asm(d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a OP_CHECKSIG)})';
+    const [tree, remainingText] = parseSCRIPT(text);
+
+    expect(tree).toEqual({
+      type: TypeAST.SCRIPT,
+      value: ScriptType.ELTR,
+      children: [
+        {
+          type: TypeAST.KEY,
+          value:
+            'c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+          children: [],
+        },
+        {
+          type: TypeAST.TREE,
+          value: undefined,
+          children: [
+            {
+              type: TypeAST.SCRIPT,
+              value: ScriptType.ASM,
+              children: [
+                {
+                  type: TypeAST.HEX,
+                  value:
+                    '20c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5ac',
+                  children: [],
+                },
+              ],
+            },
+            {
+              type: TypeAST.SCRIPT,
+              value: ScriptType.ASM,
+              children: [
+                {
+                  type: TypeAST.HEX,
+                  value:
+                    '20d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85aac',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(remainingText).toEqual('');
+
+    const res = compile(tree!);
+    expect(res.scriptPubKey().toString('hex')).toEqual(
+      '5120ec2e5b3649abf837992e92c55361ed2089a633cb69b540e90a0d098c88f0891f'
+    );
+    expect(res.taprootInternalKey).toStrictEqual(
+      'c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5'
+    );
+    expect(res.taprootHashTree).toBeDefined();
+    expect(
+      res.witnesses!(
+        '20d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85aac'
+      ).map(b => b.toString('hex'))
+    ).toEqual([
+      '20d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85aac',
+      'c4c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee52a0a73facb720b9fdea8938ab1315cd66caf024eaa3c18ed79e7491bc3959767',
+    ]);
+    expect(
+      res.witnesses!(
+        '20c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5ac'
+      ).map(b => b.toString('hex'))
+    ).toEqual([
+      '20c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5ac',
+      'c4c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5da5e27c17a7d951b00e01d1ad070d5f32175dec2511390644ae3b6caca14338a',
+    ]);
+  });
+});
+
+const validateTests: [string, boolean][] = [
+  ['', false],
+  ['eltr($test, { asm($test OP_CHECKSIG) })', false],
+  ['eltr($test, { asm($test OP_CHECKSIG), raw(00) })', true],
+  ['raw(this is not an hex value)', false],
+  ['raw(00)', true],
+  ['raw(010203040506070809101112131415)', true],
+  ['raw($test)', true],
+  ['asm(666)', false],
+  ['asm($marina OP_CHECKSIG)', true],
+  [
+    'asm(OP_CHECKSIG OP_TRUE OP_INSPECTOUTPUTASSET unexepectedstringattheend)',
+    false,
+  ],
+];
+
+describe('validate', () => {
+  for (const [text, expected] of validateTests) {
+    it(`should${expected ? '' : ' not'} validate template: "${text}"`, () => {
+      expect(validate(text)).toBe(expected);
+    });
+  }
+});

--- a/test/script-analyser.spec.ts
+++ b/test/script-analyser.spec.ts
@@ -1,0 +1,73 @@
+import { analyse, script, ScriptInputsNeeds } from '../src';
+
+interface AnalyzerTest {
+  scriptASM: string;
+  expected: ScriptInputsNeeds;
+}
+
+const TESTS: AnalyzerTest[] = [
+  {
+    scriptASM: 'OP_HASH160 OP_EQUALVERIFY',
+    expected: {
+      sigs: [],
+      hasIntrospection: false,
+      needParameters: true,
+    },
+  },
+  {
+    scriptASM:
+      'ca44d0e46b2a09e3c57981a6b8ae679e35f44dceff0bebe6ae31104db7dbac0c OP_CHECKSIG',
+    expected: {
+      sigs: [
+        {
+          pubkey:
+            'ca44d0e46b2a09e3c57981a6b8ae679e35f44dceff0bebe6ae31104db7dbac0c',
+        },
+      ],
+      hasIntrospection: false,
+      needParameters: false,
+    },
+  },
+  {
+    scriptASM:
+      'OP_INSPECTINPUTOUTPOINT OP_FALSE ca44d0e46b2a09e3c57981a6b8ae679e35f44dceff0bebe6ae31104db7dbac0c OP_CHECKSIG',
+    expected: {
+      sigs: [
+        {
+          pubkey:
+            'ca44d0e46b2a09e3c57981a6b8ae679e35f44dceff0bebe6ae31104db7dbac0c',
+        },
+      ],
+      hasIntrospection: true,
+      needParameters: false,
+    },
+  },
+  {
+    scriptASM:
+      'ca44d0e46b2a09e3c57981a6b8ae679e35f44dceff0bebe6ae31104db7dbac0c OP_CHECKSIG c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5 OP_CHECKSIG',
+    expected: {
+      sigs: [
+        {
+          pubkey:
+            'ca44d0e46b2a09e3c57981a6b8ae679e35f44dceff0bebe6ae31104db7dbac0c',
+        },
+        {
+          pubkey:
+            'c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+        },
+      ],
+      hasIntrospection: false,
+      needParameters: false,
+    },
+  },
+];
+
+describe('script-analyzer tests', () => {
+  TESTS.forEach(test => {
+    it(`should analyse ${test.scriptASM}`, () => {
+      const s = script.fromASM(test.scriptASM).toString('hex');
+      const result = analyse(s);
+      expect(result).toEqual(test.expected);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds some code from https://github.com/vulpemventures/marina/pull/345 to LDK

- `descriptors` module using to parse descriptor-like string templates -> need the "injected ecclib pattern" (new change from marina)
- `script-analyzer.ts` lets to check a script or a tapscript tree and extract some useful data to "unlock" the script.
- 2 tests files from marina PR

@tiero please review