### PR TITLE
`changeGetter` in craftSingleRecipient function

### DIFF
--- a/src/explorer/transaction.ts
+++ b/src/explorer/transaction.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import UnblindError from '../error/unblind-error';
 import { BlindingKeyGetter, isUnblindedOutput, TxInterface } from '../types';
-import { unblindOutput } from '../utils';
+import { isConfidentialOutput, unblindOutput } from '../utils';
 
 import { esploraTxToTxInterface } from './esplora';
 import { EsploraTx } from './types';
@@ -151,7 +151,7 @@ export async function unblindTransaction(
   // try to unblind prevouts, if success replace blinded prevout by unblinded prevout
   for (let inputIndex = 0; inputIndex < tx.vin.length; inputIndex++) {
     const output = tx.vin[inputIndex].prevout;
-    if (output && !isUnblindedOutput(output)) {
+    if (output && isConfidentialOutput(output)) {
       const promise = async () => {
         const blindingKey = blindingPrivateKeyGetter(
           output.prevout.script.toString('hex')

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -17,7 +17,7 @@ export function craftSingleRecipientPset(
   unspents: UnblindedOutput[],
   recipient: RecipientInterface,
   coinSelector: CoinSelector,
-  changeAddress: string,
+  changeAddressByAsset: ChangeAddressFromAssetGetter,
   substractFeeFromRecipient = false,
   satsPerByte = DEFAULT_SATS_PER_BYTE
 ) {
@@ -28,7 +28,7 @@ export function craftSingleRecipientPset(
   const firstSelection = coinSelector(throwErrorHandler)(
     unspents,
     [recipient],
-    () => changeAddress
+    changeAddressByAsset
   );
 
   const fee = createFeeOutput(
@@ -53,7 +53,7 @@ export function craftSingleRecipientPset(
   const { selectedUtxos, changeOutputs } = coinSelector(errorHandler)(
     unspents,
     [recipient, fee],
-    () => changeAddress
+    changeAddressByAsset
   );
 
   const outs = [recipient, ...changeOutputs, fee];

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -33,7 +33,7 @@ export interface WalletInterface {
   sendTx(
     recipient: RecipientInterface,
     coinSelector: CoinSelector,
-    changeAddress: string,
+    changeAddressByAsset: ChangeAddressFromAssetGetter,
     substractFee?: boolean,
     satsPerByte?: number
   ): string;
@@ -87,7 +87,7 @@ export class Wallet implements WalletInterface {
   sendTx(
     recipient: RecipientInterface,
     coinSelector: CoinSelector,
-    changeAddress: string,
+    changeAddressByAsset: ChangeAddressFromAssetGetter,
     substractFee = false,
     satsPerByte = DEFAULT_SATS_PER_BYTE
   ) {
@@ -95,7 +95,7 @@ export class Wallet implements WalletInterface {
       this.unspents,
       recipient,
       coinSelector,
-      changeAddress,
+      changeAddressByAsset,
       substractFee,
       satsPerByte
     );

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -188,7 +188,7 @@ describe('sendTx', () => {
     const pset = wallet.sendTx(
       recipient,
       greedyCoinSelector(),
-      changeAddress,
+      () => changeAddress,
       substractScenario
     );
     const recipientIndex = psetToUnsignedTx(pset).outs.findIndex(out =>


### PR DESCRIPTION
it closes #118 

let the singleRecipient pset created by WalletInterface function support several change addresses.


@tiero please review