### PR TITLE
Descriptor: single-leaf eltr tree parsing 

### DIFF
--- a/src/descriptors/index.ts
+++ b/src/descriptors/index.ts
@@ -27,6 +27,7 @@ export function makeEvaluateDescriptor(ecc: bip341.TinySecp256k1Interface) {
  */
 export function validate(template: string): boolean {
   const namespaces = findNamespaces(template);
+  console.log(namespaces);
   if (namespaces.length > 0) {
     const fakeKey = Buffer.alloc(32).toString('hex');
     const fakeCtx: Context = {
@@ -39,12 +40,12 @@ export function validate(template: string): boolean {
 
     template = preprocessor(fakeCtx, template);
   }
-
+  console.log(template);
   try {
     const [ast] = parseSCRIPT(template);
     if (!ast) return false;
     return true;
-  } catch {
+  } catch (e) {
     return false;
   }
 }

--- a/src/descriptors/index.ts
+++ b/src/descriptors/index.ts
@@ -27,7 +27,6 @@ export function makeEvaluateDescriptor(ecc: bip341.TinySecp256k1Interface) {
  */
 export function validate(template: string): boolean {
   const namespaces = findNamespaces(template);
-  console.log(namespaces);
   if (namespaces.length > 0) {
     const fakeKey = Buffer.alloc(32).toString('hex');
     const fakeCtx: Context = {
@@ -40,7 +39,6 @@ export function validate(template: string): boolean {
 
     template = preprocessor(fakeCtx, template);
   }
-  console.log(template);
   try {
     const [ast] = parseSCRIPT(template);
     if (!ast) return false;

--- a/src/descriptors/preprocessing.ts
+++ b/src/descriptors/preprocessing.ts
@@ -1,4 +1,4 @@
-const namespaceRegexp = /[$][a-z]+/;
+const namespaceRegexp = /[$][a-zA-Z0-9|@_-.]+/;
 
 export interface Context {
   // map namespace token to public key

--- a/src/descriptors/preprocessing.ts
+++ b/src/descriptors/preprocessing.ts
@@ -1,4 +1,4 @@
-const namespaceRegexp = /[$][a-zA-Z0-9|@_-.]+/;
+const namespaceRegexp = new RegExp('[$][a-zA-Z0-9|@_.-]+', 'g');
 
 export interface Context {
   // map namespace token to public key
@@ -10,7 +10,7 @@ function replaceAll(str: string, find: string, replace: string): string {
 }
 
 export function findNamespaces(text: string): Array<string> {
-  const namespaces = namespaceRegexp.exec(text);
+  const namespaces = Array.from(new Set(text.match(namespaceRegexp)));
   if (!namespaces) return [];
   return namespaces.map(n => n.slice(1)); // remove the '$' token
 }
@@ -20,6 +20,7 @@ export function processNamespaces(
   text: string
 ): string {
   const namespaces = findNamespaces(text);
+  console.log(namespaces);
   if (!namespaces.length) return text;
 
   let processedText = text;

--- a/src/descriptors/preprocessing.ts
+++ b/src/descriptors/preprocessing.ts
@@ -20,7 +20,6 @@ export function processNamespaces(
   text: string
 ): string {
   const namespaces = findNamespaces(text);
-  console.log(namespaces);
   if (!namespaces.length) return text;
 
   let processedText = text;


### PR DESCRIPTION
* eltr($test, { asm(OP_FALSE) }) is now parsable in descriptors
* several fixes about namespaces: now can include the following special char "@", ".", "_" or "-". So $marina@v0 is now a valid namespace.

@tiero please review 