### PR TITLE
Changed Mnemonic, MultisigWatchOnly, and Multisig to use the passphrase in seed generation

### DIFF
--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -14,6 +14,7 @@ import ECPairFactory from 'ecpair';
 
 export interface MnemonicOpts {
   mnemonic: string;
+  passphrase?: string;
   language?: string;
   baseDerivationPath?: string;
 }
@@ -43,7 +44,10 @@ export class Mnemonic extends MasterPublicKey implements IdentityInterface {
     checkMnemonic(args.opts.mnemonic);
 
     // retreive the wallet's seed from mnemonic
-    const walletSeed = bip39.mnemonicToSeedSync(args.opts.mnemonic);
+    const walletSeed = bip39.mnemonicToSeedSync(
+      args.opts.mnemonic,
+      args.opts.passphrase
+    );
     // generate the master private key from the wallet seed
     const network = (networks as Record<string, Network>)[args.chain];
     const bip32 = BIP32Factory(args.ecclib);

--- a/src/identity/multisig.ts
+++ b/src/identity/multisig.ts
@@ -25,7 +25,10 @@ export class Multisig extends MultisigWatchOnly implements IdentityInterface {
     checkIdentityType(args.type, IdentityType.Multisig);
     checkMnemonic(args.opts.signer.mnemonic);
 
-    const walletSeed = mnemonicToSeedSync(args.opts.signer.mnemonic);
+    const walletSeed = mnemonicToSeedSync(
+      args.opts.signer.mnemonic,
+      args.opts.signer.passphrase
+    );
     const network = (networks as Record<string, Network>)[args.chain];
     const masterPrivateKeyNode = BIP32Factory(args.ecclib).fromSeed(
       walletSeed,

--- a/src/identity/multisigWatchOnly.ts
+++ b/src/identity/multisigWatchOnly.ts
@@ -157,7 +157,7 @@ function cosignerToXPub(
   ecclib: TinySecp256k1Interface
 ): XPub {
   if (typeof cosigner === 'string') return cosigner;
-  const walletSeed = mnemonicToSeedSync(cosigner.mnemonic);
+  const walletSeed = mnemonicToSeedSync(cosigner.mnemonic, cosigner.passphrase);
   const bip32 = BIP32Factory(ecclib);
   const baseNode = bip32
     .fromSeed(walletSeed, network)

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,7 @@ export type MultisigPayment = AddressInterface & {
 
 export interface HDSignerMultisig {
   mnemonic: string;
+  passphrase?: string;
   baseDerivationPath?: string;
 }
 


### PR DESCRIPTION
This change is being made towards the goal of enabling the usage of passphrases for wallet restoration in marina as per https://github.com/vulpemventures/marina/issues/278