### PR TITLE
MasterPublicKey xpub = neutered extended public key

### DIFF
--- a/src/identity/masterpubkey.ts
+++ b/src/identity/masterpubkey.ts
@@ -6,7 +6,6 @@ import {
   checkIdentityType,
   isValidExtendedBlindKey,
   isValidXpub,
-  toXpub,
 } from '../utils';
 import { Identity, IdentityInterface, IdentityOpts } from './identity';
 
@@ -36,13 +35,11 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
   constructor(args: IdentityOpts<MasterPublicKeyOpts>) {
     super(args);
 
-    const xpub = toXpub(args.opts.masterPublicKey);
-
     // check the identity type
     checkIdentityType(args.type, IdentityType.MasterPublicKey);
 
     // validate xpub
-    if (!isValidXpub(xpub)) {
+    if (!isValidXpub(args.opts.masterPublicKey)) {
       throw new Error('Master public key is not valid');
     }
     // validate master blinding key
@@ -50,7 +47,9 @@ export class MasterPublicKey extends Identity implements IdentityInterface {
       throw new Error('Master blinding key is not valid');
     }
 
-    this.masterPublicKeyNode = BIP32Factory(args.ecclib).fromBase58(xpub);
+    this.masterPublicKeyNode = BIP32Factory(args.ecclib).fromBase58(
+      args.opts.masterPublicKey
+    );
     this.masterBlindingKeyNode = SLIP77Factory(
       args.ecclib
     ).fromMasterBlindingKey(args.opts.masterBlindingKey);

--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -6,7 +6,7 @@ import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import { SLIP77Factory, Slip77Interface } from 'slip77';
 
 import { IdentityType } from '../types';
-import { checkIdentityType, checkMnemonic, fromXpub } from '../utils';
+import { checkIdentityType, checkMnemonic, toXpub } from '../utils';
 
 import { IdentityInterface, IdentityOpts } from './identity';
 import { MasterPublicKey } from './masterpubkey';
@@ -54,13 +54,14 @@ export class Mnemonic extends MasterPublicKey implements IdentityInterface {
     const masterPrivateKeyNode = bip32.fromSeed(walletSeed, network);
 
     // compute and expose the masterPublicKey in this.masterPublicKey
-    const baseNode = masterPrivateKeyNode.derivePath(
-      args.opts.baseDerivationPath || MasterPublicKey.INITIAL_BASE_PATH
+    const masterPublicKey = toXpub(
+      masterPrivateKeyNode
+        .derivePath(
+          args.opts.baseDerivationPath || MasterPublicKey.INITIAL_BASE_PATH
+        )
+        .neutered()
+        .toBase58()
     );
-
-    const accountMasterPubKey = baseNode.neutered().toBase58();
-    // we need to convert to elements extended key
-    const masterPublicKey = fromXpub(accountMasterPubKey, args.chain);
 
     // generate the master blinding key from the seed
     const masterBlindingKeyNode = SLIP77Factory(args.ecclib).fromSeed(

--- a/src/identity/mnemonic.ts
+++ b/src/identity/mnemonic.ts
@@ -51,15 +51,12 @@ export class Mnemonic extends MasterPublicKey implements IdentityInterface {
 
     // compute and expose the masterPublicKey in this.masterPublicKey
     const baseNode = masterPrivateKeyNode.derivePath(
-      MasterPublicKey.INITIAL_BASE_PATH
+      args.opts.baseDerivationPath || MasterPublicKey.INITIAL_BASE_PATH
     );
 
-    const pubkey = baseNode.publicKey;
-    const accountPublicKey = bip32
-      .fromPublicKey(pubkey, baseNode.chainCode, baseNode.network)
-      .toBase58();
-
-    const masterPublicKey = fromXpub(accountPublicKey, args.chain);
+    const accountMasterPubKey = baseNode.neutered().toBase58();
+    // we need to convert to elements extended key
+    const masterPublicKey = fromXpub(accountMasterPubKey, args.chain);
 
     // generate the master blinding key from the seed
     const masterBlindingKeyNode = SLIP77Factory(args.ecclib).fromSeed(

--- a/test/masterpubkey.identity.test.ts
+++ b/test/masterpubkey.identity.test.ts
@@ -6,10 +6,10 @@ import {
   IdentityType,
   MasterPublicKey,
   Mnemonic,
-  fromXpub,
   masterPubKeyRestorerFromEsplora,
   MasterPublicKeyOpts,
   MnemonicOpts,
+  toXpub,
 } from '../src';
 import { faucet, sleep } from './_regtest';
 
@@ -20,9 +20,8 @@ const validOpts: IdentityOpts<MasterPublicKeyOpts> = {
   ecclib: ecc,
   type: IdentityType.MasterPublicKey,
   opts: {
-    masterPublicKey: fromXpub(
-      'tpubD6NzVbkrYhZ4XzWjD4v6Q3aNJzvGYFrCNvL5FvWkpE5yBwXwzPeUAF7KrdUKQ4feKGquMXJNn5dkm3xL8eFyDjSrD1C5s5Byh3ZTiBU1wHd',
-      'regtest'
+    masterPublicKey: toXpub(
+      'tpubD6NzVbkrYhZ4XzWjD4v6Q3aNJzvGYFrCNvL5FvWkpE5yBwXwzPeUAF7KrdUKQ4feKGquMXJNn5dkm3xL8eFyDjSrD1C5s5Byh3ZTiBU1wHd'
     ),
     masterBlindingKey:
       'c90591b4766a23ca881767626f4c2222641c944b21ad23bcadb699c031868c85',

--- a/test/mnemonic.identity.test.ts
+++ b/test/mnemonic.identity.test.ts
@@ -12,7 +12,6 @@ import {
 } from 'liquidjs-lib';
 import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
 import {
-  fromXpub,
   IdentityOpts,
   IdentityType,
   Mnemonic,
@@ -499,8 +498,8 @@ describe('Mnemonic extended public key', () => {
           baseDerivationPath: t.baseDerivationPath,
         },
       });
-      const vpub = mnemonicId.masterPublicKey;
-      assert.deepStrictEqual(vpub, fromXpub(t.xpub, 'regtest'));
+      const xpub = mnemonicId.masterPublicKey;
+      assert.deepStrictEqual(xpub, t.xpub);
     });
   }
 });

--- a/test/mnemonic.identity.test.ts
+++ b/test/mnemonic.identity.test.ts
@@ -11,8 +11,8 @@ import {
   AssetHash,
 } from 'liquidjs-lib';
 import { BlindingDataLike } from 'liquidjs-lib/src/psbt';
-
 import {
+  fromXpub,
   IdentityOpts,
   IdentityType,
   Mnemonic,
@@ -469,4 +469,38 @@ describe('Identity: Mnemonic', () => {
       });
     });
   });
+});
+
+const tests = [
+  {
+    mnemonic:
+      'envelope bubble dinner meat pumpkin despair eager inflict wet around cash mask',
+    baseDerivationPath: "m/84'/0'/0'",
+    xpub:
+      'xpub6CDtoWw3acLw7xLBtNi4qdVn64Dtzhf4KLrYjGNErU3pmt1sYqPXquDYkf6kHHeiMmQGhPEQ5WyogbjCuGTZ46EeQVKkDmDb1nu2XWUDehT',
+  },
+  {
+    mnemonic:
+      'envelope bubble dinner meat pumpkin despair eager inflict wet around cash mask',
+    baseDerivationPath: "m/84'/4'/2'",
+    xpub:
+      'xpub6DTDDZV5YtVyN78BSCdsFtvUt4hJywiRXRhKewvAzmA5jHVfXxJHBY2m2j2WqUKZQBMfB31qWPoztqNcBuB8CuEL1YMfSvSmztwUB5Z4jgu',
+  },
+];
+
+describe('Mnemonic extended public key', () => {
+  for (const t of tests) {
+    it(`should derive the correct xpub with "${t.mnemonic}" and ${t.baseDerivationPath}`, async () => {
+      const mnemonicId = new Mnemonic({
+        ...validOpts,
+        opts: {
+          ...validOpts.opts,
+          mnemonic: t.mnemonic,
+          baseDerivationPath: t.baseDerivationPath,
+        },
+      });
+      const vpub = mnemonicId.masterPublicKey;
+      assert.deepStrictEqual(vpub, fromXpub(t.xpub, 'regtest'));
+    });
+  }
 });


### PR DESCRIPTION
This PR changes the masterPublicKey of MasterPublicKey (and Mnemonic)

* instead of returning `baseNode.publicKey` as masterPublicKey, return the neutered version of baseNode `baseNode.neutered`.
* _same keys and addresses are generated_, only the masterPublicKey returned by Mnemonic and MasterPublicKey identites are different.
* neutered master extended key **is** the master xpub of the bip32 node

small fix related to baseDerivation path: it closes #127 

EDIT: the PR does not modify Multisig identities xpubs

@tiero @sekulicd please review