### PR TITLE
`ChainAPI` interface + electrs batch server support

### DIFF
--- a/src/explorer/api.ts
+++ b/src/explorer/api.ts
@@ -1,0 +1,262 @@
+import axios, { AxiosInstance } from 'axios';
+import { Transaction, TxOutput } from 'liquidjs-lib';
+import { InputInterface, Outpoint, Output, TxInterface } from '../types';
+import { EsploraTx } from './types';
+
+export interface ChainAPI {
+  fetchUtxos(addresses: string[]): Promise<Output[]>;
+  fetchTxs(addresses: string[]): Promise<TxInterface[]>;
+  addressesHasBeenUsed(addresses: string[]): Promise<boolean[]>;
+}
+
+/**
+ * Esplora is the ChainAPI implmentation for regular esplora instance
+ * Esplora also exports extra methods specific to esplora instance
+ */
+export class Electrs implements ChainAPI {
+  readonly electrsURL: string;
+  readonly axios: AxiosInstance;
+
+  constructor(url: string, axiosIns?: AxiosInstance) {
+    this.electrsURL = url;
+    this.axios = axiosIns ?? axios.create();
+  }
+
+  static fromURL(url: string): Electrs {
+    return new Electrs(url);
+  }
+
+  async addressesHasBeenUsed(addresses: string[]): Promise<boolean[]> {
+    const hasBeenUsed = async (address: string) => {
+      try {
+        const data = (
+          await axios.get(`${this.electrsURL}/address/${address}/txs`)
+        ).data;
+        return data.length > 0;
+      } catch (e) {
+        return false;
+      }
+    };
+    return Promise.all(addresses.map(hasBeenUsed));
+  }
+
+  async fetchUtxos(addresses: string[]): Promise<Output[]> {
+    const reqs = addresses.map(address =>
+      this.axios.get(`${this.electrsURL}/address/${address}/utxo`)
+    );
+    const responses = await Promise.allSettled(reqs);
+    const resolvedResponses = responses.map(r =>
+      r.status === 'fulfilled' ? r.value.data : []
+    );
+    const utxos = resolvedResponses.map(r => (r ? r : []));
+    return Promise.all(utxos.flat().map(this.outpointToUtxo()));
+  }
+
+  async fetchTxs(addresses: string[]): Promise<TxInterface[]> {
+    const esploraTxs = await Promise.all(
+      addresses.map(this.fetchAllTxsForAddress())
+    );
+    const txs = esploraTxs.flat().map(this.esploraTxToTxInterface());
+    return Promise.all(txs);
+  }
+
+  async fetchTxHex(txid: string): Promise<string> {
+    const h = (await this.axios.get(`${this.electrsURL}/tx/${txid}/hex`)).data;
+    return h;
+  }
+
+  async fetchTx(txid: string): Promise<TxInterface> {
+    return this.esploraTxToTxInterface()(
+      (await this.axios.get(`${this.electrsURL}/tx/${txid}`)).data
+    );
+  }
+
+  private fetchAllTxsForAddress() {
+    return async (address: string): Promise<EsploraTx[]> => {
+      let lastSeenTxid = undefined;
+      const txs = [];
+      do {
+        // fetch up to 25 txs
+        const nextTxs: EsploraTx[] = await this.fetch25newestTxsForAddress(
+          address,
+          lastSeenTxid
+        );
+
+        if (nextTxs.length === 0) break;
+        txs.push(...nextTxs);
+        if (nextTxs.length < 25) break;
+        lastSeenTxid = nextTxs[nextTxs.length - 1].txid;
+      } while (lastSeenTxid);
+      return txs;
+    };
+  }
+
+  private async fetch25newestTxsForAddress(
+    address: string,
+    lastSeenTxid?: string
+  ): Promise<EsploraTx[]> {
+    let url = `${this.electrsURL}/address/${address}/txs/chain`;
+    if (lastSeenTxid) {
+      url += `/${lastSeenTxid}`;
+    }
+
+    const response = await this.axios.get(url);
+    return response.data;
+  }
+
+  protected esploraTxToTxInterface() {
+    return async (esploraTx: EsploraTx): Promise<TxInterface> => {
+      const inputTxIds: string[] = [];
+      const inputVouts: number[] = [];
+
+      for (const input of esploraTx.vin) {
+        inputTxIds.push(input.txid);
+        inputVouts.push(input.vout);
+      }
+
+      const prevoutTxHexs = await Promise.all(
+        inputTxIds.map((txid, index) => {
+          if (!esploraTx.vin[index].is_pegin) return this.fetchTxHex(txid);
+          return Promise.resolve(undefined); // return undefined in case of pegin
+        })
+      );
+
+      const prevoutAsOutput = prevoutTxHexs.map(
+        (hex: string | undefined, index: number) => {
+          if (!hex) return undefined;
+          return makeOutput(
+            { txid: inputTxIds[index], vout: inputVouts[index] },
+            Transaction.fromHex(hex).outs[inputVouts[index]]
+          );
+        }
+      );
+
+      const txInputs: InputInterface[] = inputTxIds.map(
+        (txid: string, index: number) => {
+          return {
+            prevout: prevoutAsOutput[index],
+            txid: txid,
+            vout: inputVouts[index],
+            isPegin: esploraTx.vin[index].is_pegin,
+          };
+        }
+      );
+
+      const txHex = await this.fetchTxHex(esploraTx.txid);
+      const transaction = Transaction.fromHex(txHex);
+
+      const makeOutpoint = (index: number): Outpoint => ({
+        txid: esploraTx.txid,
+        vout: index,
+      });
+      const makeOutputFromTxout = (txout: TxOutput, index: number): Output =>
+        makeOutput(makeOutpoint(index), txout);
+      const txOutputs = transaction.outs.map(makeOutputFromTxout);
+
+      const tx: TxInterface = {
+        txid: esploraTx.txid,
+        vin: txInputs,
+        vout: txOutputs,
+        fee: esploraTx.fee,
+        status: {
+          confirmed: esploraTx.status.confirmed,
+          blockHash: esploraTx.status.block_hash,
+          blockHeight: esploraTx.status.block_height,
+          blockTime: esploraTx.status.block_time,
+        },
+      };
+
+      return tx;
+    };
+  }
+
+  protected outpointToUtxo() {
+    return async (outpoint: Outpoint): Promise<Output> => {
+      const prevoutHex = await this.fetchTxHex(outpoint.txid);
+      const prevout = Transaction.fromHex(prevoutHex).outs[outpoint.vout];
+      return { ...outpoint, prevout };
+    };
+  }
+}
+
+// https://electrs-batch-server.vulpem.com/
+export class ElectrsBatchServer extends Electrs implements ChainAPI {
+  constructor(
+    readonly batchServerURL: string,
+    readonly electrsURL: string,
+    axiosIns?: AxiosInstance
+  ) {
+    super(electrsURL, axiosIns);
+  }
+
+  static fromURL(_: string): ElectrsBatchServer {
+    throw new Error(
+      'Not implemented: use Electrs.fromURL or ElectrsBatchServer.fromURLs instead'
+    );
+  }
+
+  static fromURLs(url: string, electrsUrl: string): ElectrsBatchServer {
+    return new ElectrsBatchServer(url, electrsUrl);
+  }
+
+  async addressesHasBeenUsed(addresses: string[]): Promise<boolean[]> {
+    const response = await this.axios.post(
+      `${this.batchServerURL}/addresses/transactions`,
+      { addresses }
+    );
+    const results = [];
+    for (const { transaction } of response.data) {
+      results.push(transaction.length > 0);
+    }
+    return results;
+  }
+
+  async fetchUtxos(addresses: string[]): Promise<Output[]> {
+    console.time('addresses/utxo');
+    const response = await this.axios.post(
+      `${this.batchServerURL}/addresses/utxo`,
+      { addresses }
+    );
+    console.timeEnd('addresses/utxo');
+    if (response.status !== 200) {
+      throw new Error(`Error fetching utxos: ${response.status}`);
+    }
+
+    if (!response.data || !Array.isArray(response.data)) {
+      throw new Error('Invalid response from batch server');
+    }
+
+    const utxos = [];
+    for (const { utxo } of response.data) {
+      if (!Array.isArray(utxo)) continue;
+      if (utxo.length === 0) continue;
+      utxos.push(...utxo);
+    }
+
+    return await Promise.all(utxos.map(super.outpointToUtxo()));
+  }
+
+  async fetchTxs(addresses: string[]): Promise<TxInterface[]> {
+    console.time('req');
+    const response = await this.axios.post(
+      `${this.batchServerURL}/addresses/transactions`,
+      { addresses }
+    );
+    console.timeEnd('req');
+    const promises = [];
+
+    for (const { transaction } of response.data) {
+      if (transaction.length === 0) continue;
+      promises.push(...transaction.map(super.esploraTxToTxInterface()));
+    }
+    return Promise.all(promises);
+  }
+}
+
+// util function for output mapping
+function makeOutput(outpoint: Outpoint, txOutput: TxOutput): Output {
+  return {
+    ...outpoint,
+    prevout: txOutput,
+  };
+}

--- a/src/explorer/chainsync.ts
+++ b/src/explorer/chainsync.ts
@@ -1,0 +1,134 @@
+import { confidential } from 'liquidjs-lib';
+import {
+  BlindingKeyGetterAsync,
+  Output,
+  TxInterface,
+  UnblindedOutput,
+} from '../types';
+import { isConfidentialOutput } from '../utils';
+import { ChainAPI } from './api';
+import { unblindTransaction } from './transaction';
+import { tryToUnblindUtxo } from './utxos';
+
+export async function* utxosFetchGenerator(
+  addresses: string[],
+  blindingKeyGetter: BlindingKeyGetterAsync,
+  api: ChainAPI,
+  skip?: (utxo: Output) => boolean
+): AsyncGenerator<
+  UnblindedOutput,
+  { numberOfUtxos: number; errors: Error[] },
+  undefined
+> {
+  let numberOfUtxos = 0;
+  const errors = [];
+  const utxos = await api.fetchUtxos(addresses);
+  for (const utxo of utxos) {
+    if (skip?.(utxo)) continue;
+    try {
+      if (!isConfidentialOutput(utxo.prevout)) {
+        yield {
+          ...utxo,
+          unblindData: {
+            asset: utxo.prevout.asset.slice(1),
+            value: confidential
+              .confidentialValueToSatoshi(utxo.prevout.value)
+              .toString(10),
+            assetBlindingFactor: Buffer.alloc(32),
+            valueBlindingFactor: Buffer.alloc(32),
+          },
+        };
+      }
+
+      const privateBlindingKey = await blindingKeyGetter(
+        utxo.prevout.script.toString('hex')
+      );
+      if (!privateBlindingKey) {
+        // do not unblind, just skip and continue
+        continue;
+      }
+
+      const unblindedUtxo = await tryToUnblindUtxo(utxo, privateBlindingKey);
+      yield unblindedUtxo;
+      numberOfUtxos++;
+    } catch (err) {
+      console.log(err);
+      if (err instanceof Error) {
+        errors.push(err);
+      }
+
+      if (typeof err === 'string') {
+        errors.push(new Error(err));
+      }
+      errors.push(new Error('unknown error'));
+    }
+  }
+
+  return { numberOfUtxos, errors };
+}
+
+export async function* txsFetchGenerator(
+  addresses: string[],
+  blindingKeyGetter: BlindingKeyGetterAsync,
+  api: ChainAPI,
+  skip?: (tx: TxInterface) => boolean
+): AsyncGenerator<
+  TxInterface,
+  { txIDs: string[]; errors: Error[] },
+  undefined
+> {
+  const txIDs: string[] = [];
+  const errors: Error[] = [];
+  const transactions = await api.fetchTxs(addresses);
+  for (const tx of transactions) {
+    if (skip?.(tx)) continue;
+    try {
+      const { unblindedTx, errors: errs } = await unblindTransaction(
+        tx,
+        blindingKeyGetter
+      );
+      errors.push(...errs);
+      yield unblindedTx;
+
+      txIDs.push(tx.txid);
+    } catch (err) {
+      if (err instanceof Error) {
+        errors.push(err);
+      }
+
+      if (typeof err === 'string') {
+        errors.push(new Error(err));
+      }
+      errors.push(new Error('unknown error'));
+    }
+  }
+  return { txIDs, errors };
+}
+
+export async function fetchAllTxs(
+  addresses: string[],
+  blindingKeyGetter: BlindingKeyGetterAsync,
+  api: ChainAPI
+): Promise<TxInterface[]> {
+  const txs: TxInterface[] = [];
+  for await (const tx of txsFetchGenerator(addresses, blindingKeyGetter, api)) {
+    txs.push(tx);
+  }
+  return txs;
+}
+
+export async function fetchAllUtxos(
+  addresses: string[],
+  blindingKeyGetter: BlindingKeyGetterAsync,
+  api: ChainAPI
+): Promise<UnblindedOutput[]> {
+  const utxos: UnblindedOutput[] = [];
+  for await (const utxo of utxosFetchGenerator(
+    addresses,
+    blindingKeyGetter,
+    api
+  )) {
+    utxos.push(utxo);
+  }
+  return utxos;
+}

--- a/src/explorer/utxos.ts
+++ b/src/explorer/utxos.ts
@@ -98,7 +98,7 @@ export async function fetchAndUnblindUtxos(
  * @param blindPrivKey the blinding private key using to unblind
  * @param url esplora endpoint URL
  */
-async function tryToUnblindUtxo(
+export async function tryToUnblindUtxo(
   utxo: Output,
   blindPrivKey: string
 ): Promise<UnblindedOutput> {

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -4,7 +4,11 @@ import { TinySecp256k1Interface as bip32TinySecp256k1Interface } from 'bip32';
 import { Transaction, networks, confidential, TxOutput } from 'liquidjs-lib';
 import { Network } from 'liquidjs-lib/src/networks';
 import { BlindingDataLike, Psbt } from 'liquidjs-lib/src/psbt';
-import { AddressInterface, NetworkString } from '../types';
+import {
+  AddressInterface,
+  BlindingKeyGetterAsync,
+  NetworkString,
+} from '../types';
 import { IdentityType } from '../types';
 import { isConfidentialOutput, psetToUnsignedHex, decodePset } from '../utils';
 
@@ -160,4 +164,12 @@ export class Identity {
 
     return blinded.toBase64();
   }
+}
+
+export function privateBlindKeyGetter(
+  identity: IdentityInterface
+): BlindingKeyGetterAsync {
+  return async (script: string) => {
+    return identity.getBlindingPrivateKey(script);
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export * from './explorer/types';
 export * from './explorer/esplora';
 export * from './explorer/transaction';
 export * from './explorer/utxos';
+export * from './explorer/chainsync';
+export * from './explorer/api';
 
 export * from './transaction';
 export * from './wallet';
@@ -25,6 +27,7 @@ export * from './blinding';
 
 export * from './restorer/mnemonic-restorer';
 export * from './restorer/restorer';
+export * from './restorer/chainsync';
 
 export * from './script-analyser';
 export * from './descriptors';

--- a/src/restorer/chainsync.ts
+++ b/src/restorer/chainsync.ts
@@ -1,0 +1,73 @@
+import { ChainAPI } from '../explorer/api';
+import { IdentityInterface } from '../identity/identity';
+import { Mnemonic } from '../identity/mnemonic';
+import { restorerFromState } from './mnemonic-restorer';
+import { Restorer } from './restorer';
+
+function makeRestorerFromChainAPI<T extends IdentityInterface>(
+  id: T,
+  getAddress: (isChange: boolean, index: number) => string
+): Restorer<{ api: ChainAPI; gapLimit: number }, IdentityInterface> {
+  return async ({ gapLimit, api }) => {
+    const restoreFunc = async function(
+      getAddrFunc: (index: number) => Promise<string>
+    ): Promise<number | undefined> {
+      let counter = 0;
+      let next = 0;
+      let maxIndex: number | undefined = undefined;
+
+      while (counter < gapLimit) {
+        const cpyNext = next;
+        // generate a set of addresses from next to (next + gapLimit - 1)
+        const addrs = await Promise.all(
+          Array.from(Array(gapLimit).keys())
+            .map(i => i + cpyNext)
+            .map(getAddrFunc)
+        );
+
+        const hasBeenUsedArray = await api.addressesHasBeenUsed(addrs);
+
+        let indexInArray = 0;
+        for (const hasBeenUsed of hasBeenUsedArray) {
+          if (hasBeenUsed) {
+            maxIndex = indexInArray + next;
+            counter = 0;
+          } else {
+            counter++;
+            if (counter === gapLimit) return maxIndex; // duplicate the stop condition
+          }
+          indexInArray++;
+        }
+
+        next += gapLimit; // increase next
+      }
+
+      return maxIndex;
+    };
+    const restorerExternal = restoreFunc((index: number) => {
+      return Promise.resolve(getAddress(false, index));
+    });
+
+    const restorerInternal = restoreFunc((index: number) => {
+      return Promise.resolve(getAddress(true, index));
+    });
+
+    const [lastUsedExternalIndex, lastUsedInternalIndex] = await Promise.all([
+      restorerExternal,
+      restorerInternal,
+    ]);
+
+    return restorerFromState(id)({
+      lastUsedExternalIndex,
+      lastUsedInternalIndex,
+    });
+  };
+}
+
+export function mnemonicRestorerFromChain(mnemonicToRestore: Mnemonic) {
+  return makeRestorerFromChainAPI<Mnemonic>(
+    mnemonicToRestore,
+    (isChange, index) =>
+      mnemonicToRestore.getAddress(isChange, index).address.confidentialAddress
+  );
+}

--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -86,8 +86,12 @@ async function addressHasBeenUsed(
   address: string,
   esploraURL: string
 ): Promise<boolean> {
-  const data = (await axios.get(`${esploraURL}/address/${address}/txs`)).data;
-  return data.length > 0;
+  try {
+    const data = (await axios.get(`${esploraURL}/address/${address}/txs`)).data;
+    return data.length > 0;
+  } catch (e) {
+    return false;
+  }
 }
 
 /**
@@ -196,3 +200,5 @@ export function mnemonicRestorerFromState(toRestore: Mnemonic) {
 export function masterPubKeyRestorerFromState(toRestore: MasterPublicKey) {
   return restorerFromState<MasterPublicKey>(toRestore);
 }
+
+// export function restorerFromChainAPI(chainAPI: ChainAPI): Restorer<

--- a/src/restorer/mnemonic-restorer.ts
+++ b/src/restorer/mnemonic-restorer.ts
@@ -200,5 +200,3 @@ export function mnemonicRestorerFromState(toRestore: Mnemonic) {
 export function masterPubKeyRestorerFromState(toRestore: MasterPublicKey) {
   return restorerFromState<MasterPublicKey>(toRestore);
 }
-
-// export function restorerFromChainAPI(chainAPI: ChainAPI): Restorer<

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,9 @@ export type ChangeAddressFromAssetGetter = (asset: string) => string;
 
 // define function that takes a script as input and returns a blinding key (or undefined)
 export type BlindingKeyGetter = (script: string) => string | undefined;
+export type BlindingKeyGetterAsync = (
+  script: string
+) => Promise<string | undefined>;
 
 export interface RecipientInterface {
   value: number;

--- a/test/updaters.test.ts
+++ b/test/updaters.test.ts
@@ -1,0 +1,72 @@
+import axios, { AxiosError, AxiosInstance } from 'axios';
+import {
+  ElectrsBatchServer,
+  fetchAllUtxos,
+  IdentityType,
+  Mnemonic,
+  mnemonicRestorerFromChain,
+  privateBlindKeyGetter,
+} from '../src';
+import * as ecc from 'tiny-secp256k1';
+
+jest.setTimeout(100000);
+
+describe('Electrs', () => {
+  it('should fetch on mainnet using ElectrsBatchServer', async () => {
+    const id = new Mnemonic({
+      chain: 'liquid',
+      ecclib: ecc,
+      type: IdentityType.Mnemonic,
+      opts: {
+        mnemonic: ''
+      },
+    });
+
+    const api = new ElectrsBatchServer(
+      'https://electrs-batch-server.vulpem.com',
+      'https://blockstream.info/liquid/api',
+      makeRetryAxios({ maxRetryTime: 2, retryOnCodes: [500, 503] })
+    );
+    const restored = await mnemonicRestorerFromChain(id)({ api, gapLimit: 50 });
+    const addresses = await restored.getAddresses();
+    const addressesStr = addresses.map(a => a.confidentialAddress);
+    console.log(addressesStr.length);
+    console.time('utxos');
+    const utxos = await fetchAllUtxos(
+      addressesStr,
+      privateBlindKeyGetter(restored),
+      api
+    );
+    console.timeEnd('utxos');
+
+    console.time('txs');
+    const txs = await api.fetchTxs(addressesStr);
+    console.timeEnd('txs');
+    console.log(utxos.length, txs.length);
+  });
+});
+
+const makeRetryAxios = (options: {
+  maxRetryTime: number;
+  retryOnCodes: Array<number>;
+}): AxiosInstance => {
+  const instance = axios.create();
+  let counter = 0;
+  instance.interceptors.response.use(undefined, (error: AxiosError) => {
+    const config = error.config;
+    // you could defined status you want to retry, such as 503
+    // if (counter < max_time && error.response.status === retry_status_code) {
+    if (
+      counter < options.maxRetryTime &&
+      error.response &&
+      options.retryOnCodes.includes(error.response.status)
+    ) {
+      counter++;
+      return new Promise(resolve => {
+        resolve(instance(config));
+      });
+    }
+    return Promise.reject(error);
+  });
+  return instance;
+};

--- a/test/updaters.test.ts
+++ b/test/updaters.test.ts
@@ -12,13 +12,13 @@ import * as ecc from 'tiny-secp256k1';
 jest.setTimeout(100000);
 
 describe('Electrs', () => {
-  it('should fetch on mainnet using ElectrsBatchServer', async () => {
+  it.skip('should fetch on mainnet using ElectrsBatchServer', async () => {
     const id = new Mnemonic({
       chain: 'liquid',
       ecclib: ecc,
       type: IdentityType.Mnemonic,
       opts: {
-        mnemonic: ''
+        mnemonic: '',
       },
     });
 


### PR DESCRIPTION
This PR proposes a rework of updaters generators (`fetchAndUnblindUtxos` & `fetchAndUnblindTxs` are still exported)

* `fetchAllUtxos`, `fetchAllTxs` are the new "fetch" functions (+ the equivalent "generators" functions). They accept a list of addresses (as string) and handle blinding private key via `BlindKeyGetterAsync` function.
* To request the explorer, the http calls are abstracted into a new `ChainAPI` interface.
* `Electrs` class is the regular electrs ChainAPI implementation.
* `ElectrsBatchServer` extends `Electrs` with a batch-server proxy optimizing /txs and /utxo requests.
* `privateBlindKeyGetter` is an util function using to create a `BlindKeyGetter` from any `IdentityInterface`
* `makeRestorerFromChainAPI` is a factory function letting to create `Restorer` powered by `ChainAPI`. Thus we can use batchServer to restore identities.

**exemple**
```js
const api = ElectrsBatchServer.fromURLs(
  'https://electrs-batch-server.vulpem.com', 
  'https://blockstream.info/liquid/api', // regular electrs is needed to fetch prevouts
);

const utxos = await fetchAllUtxos(addressesStr, privateBlindKeyGetter(restoredID), api); // fetch and unblind unspents
const txs = await fetchAllTxs(addressesStr, privateBlindKeyGetter(restored), api); // fetch and unblind transactions
```

**Balances on deep wallet**

* with a large number of addresses, updaters using current generators has a buggy behavior (some esplora calls return unexplained 503 errors) and returns the wrong set of utxos. `FetchAllUtxos` fix it (tested on mainnet using the "  'https://electrs-batch-server.vulpem.com'" endpoint as batch server).

**Performance**

* FetchAllUtxos (~3 sec to sync 400 addresses owning 9 unspents)
* FetchAllTxs (~1min to sync 400 addresses with 500 txs in history). The "fetch prevout logic" has a huge performance cost: more about this -> #95 

We should see some "UX improvements" on utxos updating but `FetchAllTxs` stays slow compared to `FetchAndUnblind*` functions.

it closes #130 

@tiero please review