### PR TITLE
add `skip` function in ChainAPI + use /hex endpoint in `ElectrsBatchServer`

### DIFF
--- a/src/explorer/api.ts
+++ b/src/explorer/api.ts
@@ -204,7 +204,7 @@ export class ElectrsBatchServer extends Electrs implements ChainAPI {
 
   async fetchTxsHex(txids: string[]): Promise<{ txid: string; hex: string }[]> {
     const response = await this.axios.post(
-      `${this.batchServerURL}/txids/transactions/hex`,
+      `${this.batchServerURL}/transactions/hex`,
       { txids }
     );
     return response.data;

--- a/src/explorer/api.ts
+++ b/src/explorer/api.ts
@@ -6,6 +6,7 @@ import { EsploraTx } from './types';
 export interface ChainAPI {
   fetchUtxos(addresses: string[]): Promise<Output[]>;
   fetchTxs(addresses: string[]): Promise<TxInterface[]>;
+  fetchTxsHex(txids: string[]): Promise<{ txid: string; hex: string }[]>;
   addressesHasBeenUsed(addresses: string[]): Promise<boolean[]>;
 }
 
@@ -56,7 +57,9 @@ export class Electrs implements ChainAPI {
     const esploraTxs = await Promise.all(
       addresses.map(this.fetchAllTxsForAddress())
     );
-    const txs = esploraTxs.flat().map(this.esploraTxToTxInterface());
+    const txs = esploraTxs
+      .flat()
+      .map(esploraTxToTxInterface(ids => this.fetchTxsHex(ids)));
     return Promise.all(txs);
   }
 
@@ -65,8 +68,14 @@ export class Electrs implements ChainAPI {
     return h;
   }
 
+  async fetchTxsHex(txids: string[]): Promise<{ txid: string; hex: string }[]> {
+    return Promise.all(
+      txids.map(async txid => ({ txid, hex: await this.fetchTxHex(txid) }))
+    );
+  }
+
   async fetchTx(txid: string): Promise<TxInterface> {
-    return this.esploraTxToTxInterface()(
+    return esploraTxToTxInterface(ids => this.fetchTxsHex(ids))(
       (await this.axios.get(`${this.electrsURL}/tx/${txid}`)).data
     );
   }
@@ -102,72 +111,6 @@ export class Electrs implements ChainAPI {
 
     const response = await this.axios.get(url);
     return response.data;
-  }
-
-  protected esploraTxToTxInterface() {
-    return async (esploraTx: EsploraTx): Promise<TxInterface> => {
-      const inputTxIds: string[] = [];
-      const inputVouts: number[] = [];
-
-      for (const input of esploraTx.vin) {
-        inputTxIds.push(input.txid);
-        inputVouts.push(input.vout);
-      }
-
-      const prevoutTxHexs = await Promise.all(
-        inputTxIds.map((txid, index) => {
-          if (!esploraTx.vin[index].is_pegin) return this.fetchTxHex(txid);
-          return Promise.resolve(undefined); // return undefined in case of pegin
-        })
-      );
-
-      const prevoutAsOutput = prevoutTxHexs.map(
-        (hex: string | undefined, index: number) => {
-          if (!hex) return undefined;
-          return makeOutput(
-            { txid: inputTxIds[index], vout: inputVouts[index] },
-            Transaction.fromHex(hex).outs[inputVouts[index]]
-          );
-        }
-      );
-
-      const txInputs: InputInterface[] = inputTxIds.map(
-        (txid: string, index: number) => {
-          return {
-            prevout: prevoutAsOutput[index],
-            txid: txid,
-            vout: inputVouts[index],
-            isPegin: esploraTx.vin[index].is_pegin,
-          };
-        }
-      );
-
-      const txHex = await this.fetchTxHex(esploraTx.txid);
-      const transaction = Transaction.fromHex(txHex);
-
-      const makeOutpoint = (index: number): Outpoint => ({
-        txid: esploraTx.txid,
-        vout: index,
-      });
-      const makeOutputFromTxout = (txout: TxOutput, index: number): Output =>
-        makeOutput(makeOutpoint(index), txout);
-      const txOutputs = transaction.outs.map(makeOutputFromTxout);
-
-      const tx: TxInterface = {
-        txid: esploraTx.txid,
-        vin: txInputs,
-        vout: txOutputs,
-        fee: esploraTx.fee,
-        status: {
-          confirmed: esploraTx.status.confirmed,
-          blockHash: esploraTx.status.block_hash,
-          blockHeight: esploraTx.status.block_height,
-          blockTime: esploraTx.status.block_time,
-        },
-      };
-
-      return tx;
-    };
   }
 
   protected outpointToUtxo() {
@@ -212,12 +155,10 @@ export class ElectrsBatchServer extends Electrs implements ChainAPI {
   }
 
   async fetchUtxos(addresses: string[]): Promise<Output[]> {
-    console.time('addresses/utxo');
     const response = await this.axios.post(
       `${this.batchServerURL}/addresses/utxo`,
       { addresses }
     );
-    console.timeEnd('addresses/utxo');
     if (response.status !== 200) {
       throw new Error(`Error fetching utxos: ${response.status}`);
     }
@@ -236,18 +177,26 @@ export class ElectrsBatchServer extends Electrs implements ChainAPI {
     return await Promise.all(utxos.map(super.outpointToUtxo()));
   }
 
+  async fetchTxsHex(txids: string[]): Promise<{ txid: string; hex: string }[]> {
+    const response = await this.axios.post(
+      `${this.batchServerURL}/txids/transactions/hex`,
+      { txids }
+    );
+    return response.data;
+  }
+
   async fetchTxs(addresses: string[]): Promise<TxInterface[]> {
-    console.time('req');
     const response = await this.axios.post(
       `${this.batchServerURL}/addresses/transactions`,
       { addresses }
     );
-    console.timeEnd('req');
     const promises = [];
 
     for (const { transaction } of response.data) {
       if (transaction.length === 0) continue;
-      promises.push(...transaction.map(super.esploraTxToTxInterface()));
+      promises.push(
+        ...transaction.map(esploraTxToTxInterface(ids => this.fetchTxsHex(ids)))
+      );
     }
     return Promise.all(promises);
   }
@@ -258,5 +207,60 @@ function makeOutput(outpoint: Outpoint, txOutput: TxOutput): Output {
   return {
     ...outpoint,
     prevout: txOutput,
+  };
+}
+
+function esploraTxToTxInterface(
+  fetchTxFn: (txIDs: string[]) => Promise<{ txid: string; hex: string }[]>
+) {
+  return async (esploraTx: EsploraTx): Promise<TxInterface> => {
+    // make an unique call to the api to fetch all the transaction needed
+    // prevouts transactions (except pegin) + the current transaction
+    const transactions = await fetchTxFn([
+      ...esploraTx.vin.filter(input => !input.is_pegin).map(i => i.txid),
+      esploraTx.txid,
+    ]);
+
+    const makePrevout = ({ txid, vout }: Outpoint): Output => {
+      const hex = transactions.find(t => t.txid === txid);
+      if (!hex) throw new Error(`Could not find tx ${txid}`);
+      const prevout = Transaction.fromHex(hex.hex).outs[vout];
+      return makeOutput({ txid, vout }, prevout);
+    };
+
+    const txInputs: InputInterface[] = esploraTx.vin.map(input => ({
+      prevout: input.is_pegin ? undefined : makePrevout(input),
+      txid: input.txid,
+      vout: input.vout,
+      isPegin: input.is_pegin,
+    }));
+
+    const txHex = transactions.find(t => t.txid === esploraTx.txid)?.hex;
+    if (!txHex) throw new Error(`Could not find tx ${esploraTx.txid}`);
+    const transaction = Transaction.fromHex(txHex);
+
+    const makeOutpoint = (index: number): Outpoint => ({
+      txid: esploraTx.txid,
+      vout: index,
+    });
+
+    const makeOutputFromTxout = (txout: TxOutput, index: number): Output =>
+      makeOutput(makeOutpoint(index), txout);
+    const txOutputs = transaction.outs.map(makeOutputFromTxout);
+
+    const tx: TxInterface = {
+      txid: esploraTx.txid,
+      vin: txInputs,
+      vout: txOutputs,
+      fee: esploraTx.fee,
+      status: {
+        confirmed: esploraTx.status.confirmed,
+        blockHash: esploraTx.status.block_hash,
+        blockHeight: esploraTx.status.block_height,
+        blockTime: esploraTx.status.block_time,
+      },
+    };
+
+    return tx;
   };
 }


### PR DESCRIPTION
* `esploraTxToTxInterface` internal function in `ChainAPI` implementation is extremly expensive. In order to improve this, I've moved the `skip` parameters from generators to ChainAPI methods. Thus, it lets to **do not call /hex endpoints** if skip(x) returns true.
* `ElectrsBatchServer` uses new `txids/transactions/hex` endpoint from https://github.com/vulpemventures/electrs-batch-server/pull/1.
* `ChainAPI` interface defines a new method: `FetchTxsHex`.

this branch can be tested on the following marina PR: https://github.com/vulpemventures/marina/pull/392

@tiero please review