### PR TITLE
[HOTFIX] UnblindTransaction

### DIFF
--- a/src/explorer/api.ts
+++ b/src/explorer/api.ts
@@ -207,7 +207,7 @@ export class ElectrsBatchServer extends Electrs implements ChainAPI {
       `${this.batchServerURL}/transactions/hex`,
       { txids }
     );
-    return response.data;
+    return response.data || [];
   }
 
   async fetchTxs(
@@ -252,7 +252,7 @@ function esploraTxToTxInterface(
     ]);
 
     const makePrevout = ({ txid, vout }: Outpoint): Output => {
-      const hex = transactions.find(t => t.txid === txid);
+      const hex = transactions?.find(t => t.txid === txid);
       if (!hex) throw new Error(`Could not find tx ${txid}`);
       const prevout = Transaction.fromHex(hex.hex).outs[vout];
       return makeOutput({ txid, vout }, prevout);
@@ -265,7 +265,7 @@ function esploraTxToTxInterface(
       isPegin: input.is_pegin,
     }));
 
-    const txHex = transactions.find(t => t.txid === esploraTx.txid)?.hex;
+    const txHex = transactions?.find(t => t.txid === esploraTx.txid)?.hex;
     if (!txHex) throw new Error(`Could not find tx ${esploraTx.txid}`);
     const transaction = Transaction.fromHex(txHex);
 

--- a/src/explorer/transaction.ts
+++ b/src/explorer/transaction.ts
@@ -155,7 +155,7 @@ export async function unblindTransaction(
   // try to unblind prevouts, if success replace blinded prevout by unblinded prevout
   for (let inputIndex = 0; inputIndex < tx.vin.length; inputIndex++) {
     const output = tx.vin[inputIndex].prevout;
-    if (output && isConfidentialOutput(output)) {
+    if (output && isConfidentialOutput(output.prevout)) {
       const promise = async () => {
         const blindingKey = await blindingPrivateKeyGetter(
           output.prevout.script.toString('hex')


### PR DESCRIPTION
This PR fixes the `unblindTransaction` function (exported & used by updaters). The function skipped the prevouts unblinding due to bad use of `isConfidentialOutput` <- passing the prevout there fix it.

BONUS: fix #136 

@tiero @Janaka-Steph please review